### PR TITLE
chore: Cleanup repo paths and package after CNCF transfer

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: jpmcb

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: cncf/prow-github-actions@v2
         with:
           prow-commands: /assign /unassign /approve /retitle /area /kind /priority /remove /lgtm /close /reopen /lock /milestone /hold /cc /uncc
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -39,7 +39,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: cncf/prow-github-actions@v2
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -58,7 +58,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2
+      - uses: cncf/prow-github-actions@v2
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/docs/automatic-merging.md
+++ b/docs/automatic-merging.md
@@ -13,7 +13,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -35,7 +35,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -46,7 +46,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           jobs: pr-labeler
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -63,7 +63,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           prow-commands: |
             /approve
@@ -83,7 +83,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           prow-commands: |
             /assign
@@ -132,7 +132,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -147,7 +147,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v1
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jpmcb/prow-github-actions.git"
+    "url": "git+https://github.com/cncf/prow-github-actions.git"
   },
   "keywords": [
     "actions",


### PR DESCRIPTION
* Removes sponsorship yamls
* Updates docs paths with `cncf/prow-github-actions`
* Updates `package.yaml` metadata