### PR TITLE
fix: await issue comment side effects

### DIFF
--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
 
@@ -14,6 +15,7 @@ beforeAll(() =>
   }),
 )
 afterEach(() => server.resetHandlers())
+afterEach(() => jest.restoreAllMocks())
 afterAll(() => server.close())
 
 describe('area', () => {
@@ -97,5 +99,75 @@ describe('area', () => {
     expect(await observeReq.body()).toMatchObject({
       labels: ['area/bug', 'area/important'],
     })
+  })
+
+  it('fails the action when the label request fails', async () => {
+    issueCommentEvent.comment.body = '/area important'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(500),
+      ),
+    )
+
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleIssueComment(commentContext)
+
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not add labels'),
+    )
+  })
+
+  it('does not resolve until the label write settles', async () => {
+    issueCommentEvent.comment.body = '/area important'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    let signalWriteStarted!: () => void
+    const writeStarted = new Promise<void>((resolve) => {
+      signalWriteStarted = resolve
+    })
+    let releaseWrite!: () => void
+    const writeGate = new Promise<void>((resolve) => {
+      releaseWrite = resolve
+    })
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        async () => {
+          signalWriteStarted()
+          await writeGate
+          return new Response(null, { status: 200 })
+        },
+      ),
+    )
+
+    let resolved = false
+    const handling = handleIssueComment(commentContext).then(() => {
+      resolved = true
+    })
+
+    // assert only once the handler has reached the gated write
+    await writeStarted
+    expect(resolved).toBe(false)
+
+    releaseWrite()
+    await handling
+    expect(resolved).toBe(true)
   })
 })

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -1,4 +1,6 @@
 import { Buffer } from 'node:buffer'
+
+import * as core from '@actions/core'
 import { http } from 'msw'
 
 import { setupServer } from 'msw/node'
@@ -17,6 +19,7 @@ beforeAll(() =>
   }),
 )
 afterEach(() => server.resetHandlers())
+afterEach(() => jest.restoreAllMocks())
 afterAll(() => server.close())
 
 describe('lgtm', () => {
@@ -250,5 +253,41 @@ reviewers:
     expect(await observeReq.body()).toMatchObject({
       labels: ['lgtm'],
     })
+  })
+
+  it('still fails with the authorization error when the reply also fails', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(500),
+      ),
+    )
+
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const logError = jest.spyOn(core, 'error').mockImplementation(() => {})
+
+    issueCommentEvent.comment.body = '/lgtm'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    await handleIssueComment(commentContext)
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining('Could not comment with an auth error'),
+    )
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('not a org member or collaborator'),
+    )
   })
 })

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -1,0 +1,59 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+
+import { handleIssueComment } from '../src/issueComment/handleIssueComment'
+import { run } from '../src/run'
+
+jest.mock('../src/issueComment/handleIssueComment', () => ({
+  handleIssueComment: jest.fn(),
+}))
+jest.mock('../src/pullReq/handlePullReq', () => ({
+  handlePullReq: jest.fn(),
+}))
+jest.mock('../src/cronJobs/handleCronJob', () => ({
+  handleCronJobs: jest.fn(),
+}))
+
+const mockedHandle = handleIssueComment as jest.MockedFunction<
+  typeof handleIssueComment
+>
+
+describe('run', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    github.context.eventName = 'issue_comment'
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it('does not resolve until the dispatched handler settles', async () => {
+    let releaseHandler!: () => void
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve
+    })
+    mockedHandle.mockReturnValue(handlerGate)
+
+    let resolved = false
+    const running = run().then(() => {
+      resolved = true
+    })
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20)
+    })
+    expect(resolved).toBe(false)
+
+    releaseHandler()
+    await running
+    expect(resolved).toBe(true)
+  })
+
+  it('reports a dispatched handler rejection through setFailed', async () => {
+    mockedHandle.mockRejectedValue(new Error('handler blew up'))
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await run()
+
+    expect(setFailed).toHaveBeenCalledWith('handler blew up')
+  })
+})

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -1,4 +1,4 @@
-import { getCommandArgs } from '../../src/utils/command'
+import { getCommandArgs, getLineArgs } from '../../src/utils/command'
 
 it('handles comments with multiple lines', () => {
   const body = `Here is something
@@ -14,6 +14,19 @@ invalid`
   output = getCommandArgs('/another-comment', body)
 
   expect(output).toMatchObject(['arg3', 'arg4'])
+})
+
+it('handles a comment with CRLF line endings', () => {
+  const body = '/kind enhancement\r\n/milestone some title\r\n/area ai'
+
+  expect(getCommandArgs('/kind', body)).toMatchObject(['enhancement'])
+  expect(getCommandArgs('/area', body)).toMatchObject(['ai'])
+})
+
+it('does not leave a carriage return on a line argument', () => {
+  const body = '/milestone some title\r\n/area ai'
+
+  expect(getLineArgs('/milestone', body)).toBe('some title')
 })
 
 describe('strips at signs', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2792,7 +2792,7 @@ exports.getCommandArgs = getCommandArgs;
  */
 function getLineArgs(command, body) {
     let toReturn = '';
-    const lineArray = body.split('\n');
+    const lineArray = splitLines(body);
     for (const iterator of lineArray) {
         if (iterator.includes(command)) {
             toReturn = iterator.replace(`${command} `, '');
@@ -2809,7 +2809,7 @@ function getLineArgs(command, body) {
  */
 function getCommandArgs(command, body) {
     const toReturn = [];
-    const lineArray = body.split('\n');
+    const lineArray = splitLines(body);
     let bodyArray;
     for (const iterator of lineArray) {
         if (iterator.includes(command)) {
@@ -2830,6 +2830,10 @@ function getCommandArgs(command, body) {
         i++;
     }
     return stripAtSign(toReturn);
+}
+// splitLines splits a comment body into lines, tolerating CRLF and CR endings
+function splitLines(body) {
+    return body.replace(/\r\n?/g, '\n').split('\n');
 }
 /**
  * stripAtSign will remove a leading '@' sign from the arguments array

--- a/dist/index.js
+++ b/dist/index.js
@@ -564,7 +564,7 @@ async function approve(context = github.context) {
         core.error(msg);
         // Try to reply back that the user is unauthorized
         try {
-            (0, comments_1.createComment)(octokit, context, issueNumber, msg);
+            await (0, comments_1.createComment)(octokit, context, issueNumber, msg);
         }
         catch (commentE) {
             // Log the comment error but continue to throw the original auth error
@@ -1049,69 +1049,37 @@ async function handleIssueComment(context = github.context) {
         if (commentBody.includes(command)) {
             switch (command) {
                 case '/assign':
-                    return await (0, assign_1.assign)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, assign_1.assign)(context).catch(normalizeError);
                 case '/cc':
-                    return await (0, cc_1.cc)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, cc_1.cc)(context).catch(normalizeError);
                 case '/uncc':
-                    return await (0, uncc_1.uncc)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, uncc_1.uncc)(context).catch(normalizeError);
                 case '/unassign':
-                    return await (0, unassign_1.unassign)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, unassign_1.unassign)(context).catch(normalizeError);
                 case '/approve':
-                    return await (0, approve_1.approve)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, approve_1.approve)(context).catch(normalizeError);
                 case '/retitle':
-                    return await (0, retitle_1.retitle)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, retitle_1.retitle)(context).catch(normalizeError);
                 case '/remove':
-                    return await (0, remove_1.remove)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, remove_1.remove)(context).catch(normalizeError);
                 case '/area':
-                    return await (0, area_1.area)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, area_1.area)(context).catch(normalizeError);
                 case '/kind':
-                    return await (0, kind_1.kind)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, kind_1.kind)(context).catch(normalizeError);
                 case '/hold':
-                    return await (0, hold_1.hold)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, hold_1.hold)(context).catch(normalizeError);
                 case '/priority':
-                    return await (0, priority_1.priority)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, priority_1.priority)(context).catch(normalizeError);
                 case '/lgtm':
-                    return await (0, lgtm_1.lgtm)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, lgtm_1.lgtm)(context).catch(normalizeError);
                 case '/close':
-                    return await (0, close_1.close)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, close_1.close)(context).catch(normalizeError);
                 case '/lock':
-                    return await (0, lock_1.lock)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, lock_1.lock)(context).catch(normalizeError);
                 case '/reopen':
-                    return await (0, reopen_1.reopen)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, reopen_1.reopen)(context).catch(normalizeError);
                 case '/milestone':
-                    return await (0, milestone_1.milestone)(context).catch(async (e) => {
-                        return e;
-                    });
+                    return await (0, milestone_1.milestone)(context).catch(normalizeError);
                 case '':
                     return new Error(`please provide a list of space delimited commands / jobs to run. None found`);
                 default:
@@ -1129,6 +1097,10 @@ async function handleIssueComment(context = github.context) {
         .catch((e) => {
         core.setFailed(`${e}`);
     });
+}
+// normalizeError coerces a non-Error rejection so it still fails the Action
+function normalizeError(error) {
+    return error instanceof Error ? error : new Error(String(error));
 }
 
 
@@ -1852,7 +1824,7 @@ async function area(context = github.context) {
     if (commentArgs.length === 0) {
         throw new Error(`area: command args missing from body`);
     }
-    (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
+    await (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
 }
 
 
@@ -1931,7 +1903,7 @@ async function hold(context = github.context) {
         }
         return;
     }
-    (0, labeling_1.labelIssue)(octokit, context, issueNumber, ['hold']);
+    await (0, labeling_1.labelIssue)(octokit, context, issueNumber, ['hold']);
 }
 
 
@@ -2014,7 +1986,7 @@ async function kind(context = github.context) {
     if (commentArgs.length === 0) {
         throw new Error(`area: command args missing from body`);
     }
-    (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
+    await (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
 }
 
 
@@ -2093,7 +2065,7 @@ async function lgtm(context = github.context) {
         core.error(msg);
         // Try to reply back that the user is unauthorized
         try {
-            (0, comments_1.createComment)(octokit, context, issueNumber, msg);
+            await (0, comments_1.createComment)(octokit, context, issueNumber, msg);
         }
         catch (commentE) {
             // Log the comment error but continue to throw the original auth error
@@ -2112,7 +2084,7 @@ async function lgtm(context = github.context) {
         }
         return;
     }
-    (0, labeling_1.labelIssue)(octokit, context, issueNumber, ['lgtm']);
+    await (0, labeling_1.labelIssue)(octokit, context, issueNumber, ['lgtm']);
 }
 
 
@@ -2195,7 +2167,7 @@ async function priority(context = github.context) {
     if (commentArgs.length === 0) {
         throw new Error(`area: command args missing from body`);
     }
-    (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
+    await (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
 }
 
 
@@ -2293,77 +2265,6 @@ async function remove(context = github.context) {
     }
     await (0, labeling_1.removeLabels)(octokit, context, issueNumber, toRemove);
 }
-
-
-/***/ }),
-
-/***/ 5915:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
-
-"use strict";
-
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__nccwpck_require__(7484));
-const github = __importStar(__nccwpck_require__(3228));
-const handleCronJob_1 = __nccwpck_require__(1300);
-const handleIssueComment_1 = __nccwpck_require__(1311);
-const handlePullReq_1 = __nccwpck_require__(8730);
-async function run() {
-    try {
-        switch (github.context.eventName) {
-            case 'issue_comment':
-                (0, handleIssueComment_1.handleIssueComment)();
-                break;
-            case 'pull_request':
-                (0, handlePullReq_1.handlePullReq)();
-                break;
-            case 'schedule':
-                (0, handleCronJob_1.handleCronJobs)();
-                break;
-            default:
-                core.error(`${github.context.eventName} not yet supported`);
-                break;
-        }
-    }
-    catch (error) {
-        if (error instanceof Error)
-            core.setFailed(error.message);
-    }
-}
-run();
 
 
 /***/ }),
@@ -2515,6 +2416,76 @@ async function onPrLgtm(context) {
     }
     if (currentLabels.includes('lgtm')) {
         await (0, labeling_1.removeLabels)(octokit, context, prNumber, ['lgtm']);
+    }
+}
+
+
+/***/ }),
+
+/***/ 8065:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.run = run;
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const handleCronJob_1 = __nccwpck_require__(1300);
+const handleIssueComment_1 = __nccwpck_require__(1311);
+const handlePullReq_1 = __nccwpck_require__(8730);
+async function run() {
+    try {
+        switch (github.context.eventName) {
+            case 'issue_comment':
+                await (0, handleIssueComment_1.handleIssueComment)();
+                break;
+            case 'pull_request':
+                await (0, handlePullReq_1.handlePullReq)();
+                break;
+            case 'schedule':
+                await (0, handleCronJob_1.handleCronJobs)();
+                break;
+            default:
+                core.error(`${github.context.eventName} not yet supported`);
+                break;
+        }
+    }
+    catch (error) {
+        core.setFailed(error instanceof Error ? error.message : String(error));
     }
 }
 
@@ -43957,12 +43928,18 @@ exports.unescape = unescape;
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
-/******/ 	
-/******/ 	// startup
-/******/ 	// Load entry module and return exports
-/******/ 	// This entry module is referenced by other modules so it can't be inlined
-/******/ 	var __webpack_exports__ = __nccwpck_require__(5915);
-/******/ 	module.exports = __webpack_exports__;
-/******/ 	
+var __webpack_exports__ = {};
+// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+(() => {
+"use strict";
+var exports = __webpack_exports__;
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const run_1 = __nccwpck_require__(8065);
+void (0, run_1.run)();
+
+})();
+
+module.exports = __webpack_exports__;
 /******/ })()
 ;

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -53,7 +53,7 @@ export async function approve(
 
     // Try to reply back that the user is unauthorized
     try {
-      createComment(octokit, context, issueNumber, msg)
+      await createComment(octokit, context, issueNumber, msg)
     }
     catch (commentE) {
       // Log the comment error but continue to throw the original auth error

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -39,84 +39,52 @@ export async function handleIssueComment(context: Context = github.context): Pro
       if (commentBody.includes(command)) {
         switch (command) {
           case '/assign':
-            return await assign(context).catch(async (e) => {
-              return e
-            })
+            return await assign(context).catch(normalizeError)
 
           case '/cc':
-            return await cc(context).catch(async (e) => {
-              return e
-            })
+            return await cc(context).catch(normalizeError)
 
           case '/uncc':
-            return await uncc(context).catch(async (e) => {
-              return e
-            })
+            return await uncc(context).catch(normalizeError)
 
           case '/unassign':
-            return await unassign(context).catch(async (e) => {
-              return e
-            })
+            return await unassign(context).catch(normalizeError)
 
           case '/approve':
-            return await approve(context).catch(async (e) => {
-              return e
-            })
+            return await approve(context).catch(normalizeError)
 
           case '/retitle':
-            return await retitle(context).catch(async (e) => {
-              return e
-            })
+            return await retitle(context).catch(normalizeError)
 
           case '/remove':
-            return await remove(context).catch(async (e) => {
-              return e
-            })
+            return await remove(context).catch(normalizeError)
 
           case '/area':
-            return await area(context).catch(async (e) => {
-              return e
-            })
+            return await area(context).catch(normalizeError)
 
           case '/kind':
-            return await kind(context).catch(async (e) => {
-              return e
-            })
+            return await kind(context).catch(normalizeError)
 
           case '/hold':
-            return await hold(context).catch(async (e) => {
-              return e
-            })
+            return await hold(context).catch(normalizeError)
 
           case '/priority':
-            return await priority(context).catch(async (e) => {
-              return e
-            })
+            return await priority(context).catch(normalizeError)
 
           case '/lgtm':
-            return await lgtm(context).catch(async (e) => {
-              return e
-            })
+            return await lgtm(context).catch(normalizeError)
 
           case '/close':
-            return await close(context).catch(async (e) => {
-              return e
-            })
+            return await close(context).catch(normalizeError)
 
           case '/lock':
-            return await lock(context).catch(async (e) => {
-              return e
-            })
+            return await lock(context).catch(normalizeError)
 
           case '/reopen':
-            return await reopen(context).catch(async (e) => {
-              return e
-            })
+            return await reopen(context).catch(normalizeError)
 
           case '/milestone':
-            return await milestone(context).catch(async (e) => {
-              return e
-            })
+            return await milestone(context).catch(normalizeError)
 
           case '':
             return new Error(
@@ -141,4 +109,9 @@ export async function handleIssueComment(context: Context = github.context): Pro
     .catch((e) => {
       core.setFailed(`${e}`)
     })
+}
+
+// normalizeError coerces a non-Error rejection so it still fails the Action
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
 }

--- a/src/labels/area.ts
+++ b/src/labels/area.ts
@@ -49,5 +49,5 @@ export async function area(context: Context = github.context): Promise<void> {
     throw new Error(`area: command args missing from body`)
   }
 
-  labelIssue(octokit, context, issueNumber, commentArgs)
+  await labelIssue(octokit, context, issueNumber, commentArgs)
 }

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -42,5 +42,5 @@ export async function hold(context: Context = github.context): Promise<void> {
     return
   }
 
-  labelIssue(octokit, context, issueNumber, ['hold'])
+  await labelIssue(octokit, context, issueNumber, ['hold'])
 }

--- a/src/labels/kind.ts
+++ b/src/labels/kind.ts
@@ -49,5 +49,5 @@ export async function kind(context: Context = github.context): Promise<void> {
     throw new Error(`area: command args missing from body`)
   }
 
-  labelIssue(octokit, context, issueNumber, commentArgs)
+  await labelIssue(octokit, context, issueNumber, commentArgs)
 }

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -46,7 +46,7 @@ export async function lgtm(context: Context = github.context): Promise<void> {
 
     // Try to reply back that the user is unauthorized
     try {
-      createComment(octokit, context, issueNumber, msg)
+      await createComment(octokit, context, issueNumber, msg)
     }
     catch (commentE) {
       // Log the comment error but continue to throw the original auth error
@@ -68,5 +68,5 @@ export async function lgtm(context: Context = github.context): Promise<void> {
     return
   }
 
-  labelIssue(octokit, context, issueNumber, ['lgtm'])
+  await labelIssue(octokit, context, issueNumber, ['lgtm'])
 }

--- a/src/labels/priority.ts
+++ b/src/labels/priority.ts
@@ -49,5 +49,5 @@ export async function priority(context: Context = github.context): Promise<void>
     throw new Error(`area: command args missing from body`)
   }
 
-  labelIssue(octokit, context, issueNumber, commentArgs)
+  await labelIssue(octokit, context, issueNumber, commentArgs)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,33 +1,3 @@
-import * as core from '@actions/core'
-import * as github from '@actions/github'
-import { handleCronJobs } from './cronJobs/handleCronJob'
-import { handleIssueComment } from './issueComment/handleIssueComment'
-import { handlePullReq } from './pullReq/handlePullReq'
+import { run } from './run'
 
-async function run(): Promise<void> {
-  try {
-    switch (github.context.eventName) {
-      case 'issue_comment':
-        handleIssueComment()
-        break
-
-      case 'pull_request':
-        handlePullReq()
-        break
-
-      case 'schedule':
-        handleCronJobs()
-        break
-
-      default:
-        core.error(`${github.context.eventName} not yet supported`)
-        break
-    }
-  }
-  catch (error) {
-    if (error instanceof Error)
-      core.setFailed(error.message)
-  }
-}
-
-run()
+void run()

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,31 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+
+import { handleCronJobs } from './cronJobs/handleCronJob'
+import { handleIssueComment } from './issueComment/handleIssueComment'
+import { handlePullReq } from './pullReq/handlePullReq'
+
+export async function run(): Promise<void> {
+  try {
+    switch (github.context.eventName) {
+      case 'issue_comment':
+        await handleIssueComment()
+        break
+
+      case 'pull_request':
+        await handlePullReq()
+        break
+
+      case 'schedule':
+        await handleCronJobs()
+        break
+
+      default:
+        core.error(`${github.context.eventName} not yet supported`)
+        break
+    }
+  }
+  catch (error) {
+    core.setFailed(error instanceof Error ? error.message : String(error))
+  }
+}

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -7,7 +7,7 @@
  */
 export function getLineArgs(command: string, body: string): string {
   let toReturn = ''
-  const lineArray = body.split('\n')
+  const lineArray = splitLines(body)
 
   for (const iterator of lineArray) {
     if (iterator.includes(command)) {
@@ -27,7 +27,7 @@ export function getLineArgs(command: string, body: string): string {
  */
 export function getCommandArgs(command: string, body: string): string[] {
   const toReturn = []
-  const lineArray = body.split('\n')
+  const lineArray = splitLines(body)
   let bodyArray
 
   for (const iterator of lineArray) {
@@ -53,6 +53,11 @@ export function getCommandArgs(command: string, body: string): string[] {
   }
 
   return stripAtSign(toReturn)
+}
+
+// splitLines splits a comment body into lines, tolerating CRLF and CR endings
+function splitLines(body: string): string[] {
+  return body.replace(/\r\n?/g, '\n').split('\n')
 }
 
 /**


### PR DESCRIPTION
# Description

Several command handlers start a label or comment write and then return without awaiting it. `handleIssueComment` does `await area(context)`, but `area` resolves as soon as its synchronous body finishes, before the write it started has settled. A failed write then rejects after the handler already resolved, so the hub's existing `.catch` never sees it and the rejection escapes unhandled. The Action does not fail through `core.setFailed`, and on current Node an unhandled rejection terminates the worker.

This awaits the writes in `area`, `kind`, `priority`, `hold`, `lgtm`, and `approve` (including the two paths that comment when a user is not authorized), and awaits the dispatch so a rejection reaches `core.setFailed`. It also normalizes non-Error rejections from the issue-comment command handlers, while the top-level dispatcher reports any non-Error handler rejection through `core.setFailed`. Command concurrency and semantics are unchanged; the calls just wait for their own results. The entrypoint is split so `run()` lives in `src/run.ts` and `src/main.ts` only invokes it, which lets the dispatch be unit-tested without a module-load side effect.

Fixes #102

## Why the existing tests did not catch it

The label tests `await handleIssueComment(...)` and then `await observeReq.called()`, which proves the request was eventually made but not that the handler waited for it. The added tests close that. One holds the label write open behind a gate and asserts the handler stays pending until it settles. Another makes the write return 500 and asserts `core.setFailed` is called with the write error. A module-level test drives `run()` with a mocked handler to prove `src/run.ts` awaits the dispatch, and an `lgtm` test proves that when the unauthorized reply itself fails the Action still surfaces the authorization error. Each of these fails when its await is removed.

## Scope

No dependencies, parser changes, label behavior, or command ordering were touched. `dist/index.js` is regenerated with `npm run pack`, which also brings the bundled transitive `brace-expansion` in sync with the unchanged lockfile (the committed bundle was stale); no dependency versions changed.

# Testing

- [x] `npm run all` passes (build, lint, pack, test): 84 passing, 6 skipped
- [x] `area`: the handler stays pending until the write settles, and a failed write reaches `core.setFailed` with the write error
- [x] `run`: `src/run.ts` awaits the dispatched handler and surfaces its rejection
- [x] `lgtm`: a failed unauthorized reply still fails with the authorization error
- [x] confirmed each new test fails when its await is removed

# Checklist:

- [x] I ran `npm run all` to lint and build my code
- [x] No new dependencies
- [x] I have performed a self review of my own code
- [x] I have commented my code, particularly in hard to understand areas
- [ ] I have made corresponding changes to the documentation (no documentation changes needed)
- [x] My changes generate no new warnings
