### PR TITLE
feat: add the /meow command

### DIFF
--- a/__tests__/issueCommentTest/meow.test.ts
+++ b/__tests__/issueCommentTest/meow.test.ts
@@ -1,0 +1,442 @@
+import * as core from '@actions/core'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import { meowConfig } from '../../src/issueComment/meow'
+import * as comments from '../../src/utils/comments'
+import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+import * as utils from '../testUtils'
+
+const catApi = 'https://api.thecatapi.com/v1/images/search'
+
+const server = setupServer()
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => {
+  server.resetHandlers()
+  jest.restoreAllMocks()
+})
+afterAll(() => server.close())
+
+function contextFor(body: string) {
+  issueCommentEvent.comment.body = body
+  return new utils.MockContext(issueCommentEvent)
+}
+
+describe('/meow', () => {
+  let createComment: jest.SpiedFunction<typeof comments.createComment>
+
+  beforeEach(() => {
+    utils.setupActionsEnv('/meow')
+    meowConfig.timeoutMs = 10_000
+    meowConfig.retryDelayMs = 0
+    meowConfig.maxAttempts = 3
+    createComment = jest.spyOn(comments, 'createComment').mockResolvedValue()
+  })
+
+  it('comments with a cat image for a standalone /meow', async () => {
+    server.use(
+      http.get(catApi, () =>
+        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+    )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledTimes(1)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      '![cat](<https://cataas.com/cat.jpg>)',
+    )
+  })
+
+  it('safely renders a url that contains parentheses', async () => {
+    const url = 'https://example.test/cats/a_(b).jpg'
+    server.use(http.get(catApi, () => HttpResponse.json([{ url }])))
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      `![cat](<${url}>)`,
+    )
+  })
+
+  it.each(['/meowvie', '/meow-debug', '/meow cat', 'please run /meow later'])(
+    'does not trigger for %p',
+    async (body) => {
+      await handleIssueComment(contextFor(body))
+      expect(createComment).not.toHaveBeenCalled()
+    },
+  )
+
+  it('matches a standalone /meow once in a CRLF comment', async () => {
+    server.use(
+      http.get(catApi, () =>
+        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+    )
+
+    await handleIssueComment(contextFor('/meow\r\n/something-else'))
+
+    expect(createComment).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient status and then succeeds', async () => {
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        if (calls === 1)
+          return new HttpResponse(null, { status: 503 })
+        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+      }),
+    )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(2)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      '![cat](<https://cataas.com/cat.jpg>)',
+    )
+  })
+
+  it('degrades to a note when the cat api keeps failing', async () => {
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        return new HttpResponse(null, { status: 500 })
+      }),
+    )
+    const warning = jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(meowConfig.maxAttempts)
+    expect(warning).toHaveBeenCalled()
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note on a network error', async () => {
+    server.use(http.get(catApi, () => HttpResponse.error()))
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note when the cat api times out and does not retry', async () => {
+    meowConfig.timeoutMs = 50
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        return new Promise(() => {})
+      }),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(1)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note when the response has no usable url', async () => {
+    server.use(http.get(catApi, () => HttpResponse.json([])))
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('sends the api key header only when configured', async () => {
+    process.env['INPUT_CAT-API-KEY'] = 'secret-key'
+    const setSecret = jest.spyOn(core, 'setSecret').mockImplementation(() => {})
+    let seenKey: string | null = null
+    server.use(
+      http.get(catApi, ({ request }) => {
+        seenKey = request.headers.get('x-api-key')
+        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+      }),
+    )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(setSecret).toHaveBeenCalledWith('secret-key')
+    expect(seenKey).toBe('secret-key')
+  })
+
+  it('fails the action when the github comment write fails', async () => {
+    server.use(
+      http.get(catApi, () =>
+        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+    )
+    createComment.mockRejectedValue(new Error('could not add comment: boom'))
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not add comment'),
+    )
+  })
+
+  it('does not send an api key header when none is configured', async () => {
+    let sentKey: boolean | null = null
+    server.use(
+      http.get(catApi, ({ request }) => {
+        sentKey = request.headers.has('x-api-key')
+        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+      }),
+    )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(sentKey).toBe(false)
+  })
+
+  it('does not retry a client error', async () => {
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        return new HttpResponse(null, { status: 400 })
+      }),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(1)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('requests a single medium image', async () => {
+    let requestedUrl: string | null = null
+    server.use(
+      http.get(catApi, ({ request }) => {
+        requestedUrl = request.url
+        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+      }),
+    )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(requestedUrl).toContain('limit=1')
+    expect(requestedUrl).toContain('size=med')
+  })
+
+  it('retries a network error up to the attempt limit', async () => {
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        return HttpResponse.error()
+      }),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(meowConfig.maxAttempts)
+  })
+
+  it('degrades to a note for a non-https image url', async () => {
+    server.use(
+      http.get(catApi, () =>
+        HttpResponse.json([{ url: 'http://cataas.com/cat.jpg' }])),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note for a url that embeds credentials', async () => {
+    server.use(
+      http.get(catApi, () =>
+        HttpResponse.json([{ url: 'https://user:pass@cataas.com/cat.jpg' }])),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('does not follow a redirect or forward the key', async () => {
+    process.env['INPUT_CAT-API-KEY'] = 'secret-key'
+    // the redirect target is intentionally not mocked: onUnhandledRequest error
+    // fails the test if the request is ever followed there
+    server.use(
+      http.get(catApi, () =>
+        new HttpResponse(null, {
+          status: 302,
+          headers: { location: 'https://redirect.example/cat' },
+        })),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note when the first item has no url', async () => {
+    server.use(http.get(catApi, () => HttpResponse.json([{}])))
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note when the url does not parse', async () => {
+    server.use(
+      http.get(catApi, () => HttpResponse.json([{ url: 'not a url' }])),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('degrades to a note for an excessively long url', async () => {
+    const longUrl = `https://cataas.com/${'a'.repeat(5000)}.jpg`
+    server.use(http.get(catApi, () => HttpResponse.json([{ url: longUrl }])))
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('does not retry a rate limit', async () => {
+    let calls = 0
+    server.use(
+      http.get(catApi, () => {
+        calls++
+        return new HttpResponse(null, { status: 429 })
+      }),
+    )
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(calls).toBe(1)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('cancels the response body before retrying', async () => {
+    let cancelled = false
+    const stream = new ReadableStream({
+      cancel() {
+        cancelled = true
+      },
+    })
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(stream, { status: 503 }))
+      .mockResolvedValueOnce(
+        Response.json([{ url: 'https://cataas.com/cat.jpg' }]),
+      )
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(cancelled).toBe(true)
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      '![cat](<https://cataas.com/cat.jpg>)',
+    )
+  })
+
+  it('cancels the response body for a non-retryable status', async () => {
+    let cancelled = false
+    const stream = new ReadableStream({
+      cancel() {
+        cancelled = true
+      },
+    })
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(stream, { status: 400 }))
+    jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(cancelled).toBe(true)
+  })
+})

--- a/__tests__/issueCommentTest/meow.test.ts
+++ b/__tests__/issueCommentTest/meow.test.ts
@@ -37,7 +37,7 @@ describe('/meow', () => {
   it('comments with a cat image for a standalone /meow', async () => {
     server.use(
       http.get(catApi, () =>
-        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+        HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])),
     )
 
     await handleIssueComment(contextFor('/meow'))
@@ -47,12 +47,12 @@ describe('/meow', () => {
       expect.anything(),
       expect.anything(),
       1,
-      '![cat](<https://cataas.com/cat.jpg>)',
+      '![cat](<https://cdn2.thecatapi.com/images/cat.jpg>)',
     )
   })
 
   it('safely renders a url that contains parentheses', async () => {
-    const url = 'https://example.test/cats/a_(b).jpg'
+    const url = 'https://cdn2.thecatapi.com/images/a_(b).jpg'
     server.use(http.get(catApi, () => HttpResponse.json([{ url }])))
 
     await handleIssueComment(contextFor('/meow'))
@@ -76,7 +76,7 @@ describe('/meow', () => {
   it('matches a standalone /meow once in a CRLF comment', async () => {
     server.use(
       http.get(catApi, () =>
-        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+        HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])),
     )
 
     await handleIssueComment(contextFor('/meow\r\n/something-else'))
@@ -91,7 +91,7 @@ describe('/meow', () => {
         calls++
         if (calls === 1)
           return new HttpResponse(null, { status: 503 })
-        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+        return HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])
       }),
     )
 
@@ -102,7 +102,7 @@ describe('/meow', () => {
       expect.anything(),
       expect.anything(),
       1,
-      '![cat](<https://cataas.com/cat.jpg>)',
+      '![cat](<https://cdn2.thecatapi.com/images/cat.jpg>)',
     )
   })
 
@@ -185,7 +185,7 @@ describe('/meow', () => {
     server.use(
       http.get(catApi, ({ request }) => {
         seenKey = request.headers.get('x-api-key')
-        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+        return HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])
       }),
     )
 
@@ -198,7 +198,7 @@ describe('/meow', () => {
   it('fails the action when the github comment write fails', async () => {
     server.use(
       http.get(catApi, () =>
-        HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])),
+        HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])),
     )
     createComment.mockRejectedValue(new Error('could not add comment: boom'))
     const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
@@ -215,7 +215,7 @@ describe('/meow', () => {
     server.use(
       http.get(catApi, ({ request }) => {
         sentKey = request.headers.has('x-api-key')
-        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+        return HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])
       }),
     )
 
@@ -250,7 +250,7 @@ describe('/meow', () => {
     server.use(
       http.get(catApi, ({ request }) => {
         requestedUrl = request.url
-        return HttpResponse.json([{ url: 'https://cataas.com/cat.jpg' }])
+        return HttpResponse.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }])
       }),
     )
 
@@ -278,7 +278,7 @@ describe('/meow', () => {
   it('degrades to a note for a non-https image url', async () => {
     server.use(
       http.get(catApi, () =>
-        HttpResponse.json([{ url: 'http://cataas.com/cat.jpg' }])),
+        HttpResponse.json([{ url: 'http://cdn2.thecatapi.com/images/cat.jpg' }])),
     )
     jest.spyOn(core, 'warning').mockImplementation(() => {})
 
@@ -295,12 +295,47 @@ describe('/meow', () => {
   it('degrades to a note for a url that embeds credentials', async () => {
     server.use(
       http.get(catApi, () =>
-        HttpResponse.json([{ url: 'https://user:pass@cataas.com/cat.jpg' }])),
+        HttpResponse.json([{ url: 'https://user:pass@cdn2.thecatapi.com/images/cat.jpg' }])),
     )
     jest.spyOn(core, 'warning').mockImplementation(() => {})
 
     await handleIssueComment(contextFor('/meow'))
 
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      'The cat API is unavailable right now.',
+    )
+  })
+
+  it('renders an image served from the provider s3 bucket', async () => {
+    const url = 'https://s3.us-west-2.amazonaws.com/cdn2.thecatapi.com/images/cat.jpg'
+    server.use(http.get(catApi, () => HttpResponse.json([{ url }])))
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      1,
+      `![cat](<${url}>)`,
+    )
+  })
+
+  it.each([
+    'https://cataas.com/cat.jpg',
+    'https://s3.us-west-2.amazonaws.com/other-bucket/cat.jpg',
+    'https://cdn2.thecatapi.com.evil.example/cat.jpg',
+  ])('degrades to a note for an image from an unexpected host %p', async (url) => {
+    server.use(http.get(catApi, () => HttpResponse.json([{ url }])))
+    const warning = jest.spyOn(core, 'warning').mockImplementation(() => {})
+
+    await handleIssueComment(contextFor('/meow'))
+
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining('unexpected host'),
+    )
     expect(createComment).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
@@ -363,7 +398,7 @@ describe('/meow', () => {
   })
 
   it('degrades to a note for an excessively long url', async () => {
-    const longUrl = `https://cataas.com/${'a'.repeat(5000)}.jpg`
+    const longUrl = `https://cdn2.thecatapi.com/images/${'a'.repeat(5000)}.jpg`
     server.use(http.get(catApi, () => HttpResponse.json([{ url: longUrl }])))
     jest.spyOn(core, 'warning').mockImplementation(() => {})
 
@@ -409,7 +444,7 @@ describe('/meow', () => {
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(new Response(stream, { status: 503 }))
       .mockResolvedValueOnce(
-        Response.json([{ url: 'https://cataas.com/cat.jpg' }]),
+        Response.json([{ url: 'https://cdn2.thecatapi.com/images/cat.jpg' }]),
       )
 
     await handleIssueComment(contextFor('/meow'))
@@ -419,7 +454,7 @@ describe('/meow', () => {
       expect.anything(),
       expect.anything(),
       1,
-      '![cat](<https://cataas.com/cat.jpg>)',
+      '![cat](<https://cdn2.thecatapi.com/images/cat.jpg>)',
     )
   })
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   merge-method:
     description: "Strategy for Prow-github-actions to take when merging a pull request using the lgtm cron-job. Can be 'squash', 'rebase', or 'merge'. Defaults to 'merge'"
     required: false
+  cat-api-key:
+    description: 'Optional API key for the /meow image provider (https://thecatapi.com), sent as the x-api-key header. Provide it from a repository secret. The action registers it for runner masking before use and never intentionally includes it in request URLs or GitHub comments.'
+    required: false
 branding:
   color: blue
   icon: anchor

--- a/dist/index.js
+++ b/dist/index.js
@@ -1417,7 +1417,17 @@ function parseCatImage(value) {
         || image.password !== '') {
         throw new Error('cat api returned an unusable image url');
     }
+    if (!isTrustedImageSource(image))
+        throw new Error('cat api returned an image from an unexpected host');
     return image;
+}
+// only render images the provider actually serves; a compromised or spoofed
+// api response must not be able to embed an arbitrary third-party url
+function isTrustedImageSource(image) {
+    if (image.hostname === 'cdn2.thecatapi.com')
+        return true;
+    return image.hostname === 's3.us-west-2.amazonaws.com'
+        && image.pathname.startsWith('/cdn2.thecatapi.com/');
 }
 function delay(ms) {
     return new Promise((resolve) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1027,6 +1027,7 @@ const assign_1 = __nccwpck_require__(7752);
 const cc_1 = __nccwpck_require__(423);
 const close_1 = __nccwpck_require__(6273);
 const lock_1 = __nccwpck_require__(8886);
+const meow_1 = __nccwpck_require__(8841);
 const milestone_1 = __nccwpck_require__(2771);
 const reopen_1 = __nccwpck_require__(1328);
 const retitle_1 = __nccwpck_require__(7068);
@@ -1080,6 +1081,8 @@ async function handleIssueComment(context = github.context) {
                     return await (0, reopen_1.reopen)(context).catch(normalizeError);
                 case '/milestone':
                     return await (0, milestone_1.milestone)(context).catch(normalizeError);
+                case '/meow':
+                    return await (0, meow_1.meow)(context).catch(normalizeError);
                 case '':
                     return new Error(`please provide a list of space delimited commands / jobs to run. None found`);
                 default:
@@ -1256,6 +1259,170 @@ async function lock(context = github.context) {
     else {
         throw new Error(`commenter is not a collaborator user`);
     }
+}
+
+
+/***/ }),
+
+/***/ 8841:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.meowConfig = void 0;
+exports.meow = meow;
+const core = __importStar(__nccwpck_require__(7484));
+const github = __importStar(__nccwpck_require__(3228));
+const rest_1 = __nccwpck_require__(5772);
+const comments_1 = __nccwpck_require__(2666);
+const catApi = 'https://api.thecatapi.com/v1/images/search?limit=1&size=med';
+// a line of exactly /meow, not /meowvie or a mention
+const meowCommand = /^[\t ]*\/meow[\t ]*$/m;
+// bounded so a slow provider cannot stall the runner; exported so tests can shrink the waits
+exports.meowConfig = {
+    timeoutMs: 5_000,
+    maxAttempts: 3,
+    retryDelayMs: 500,
+};
+/**
+ * /meow replies with a random cat image
+ *
+ * @param context - the github actions event context
+ */
+async function meow(context = github.context) {
+    if (!hasMeowCommand(context.payload.comment?.body))
+        return;
+    const token = core.getInput('github-token', { required: true });
+    const octokit = new rest_1.Octokit({ auth: token });
+    const issueNumber = context.payload.issue?.number;
+    if (issueNumber === undefined) {
+        throw new Error(`github context payload missing issue number: ${context.payload}`);
+    }
+    // a provider outage degrades to a note; only the github write can fail the action
+    let body;
+    try {
+        const image = await fetchCatImage();
+        body = `![cat](<${image.href}>)`;
+    }
+    catch (error) {
+        core.warning(`Could not fetch a cat image: ${error}`);
+        body = 'The cat API is unavailable right now.';
+    }
+    await (0, comments_1.createComment)(octokit, context, issueNumber, body);
+}
+// hasMeowCommand reports whether the body has a standalone /meow line
+function hasMeowCommand(body) {
+    return typeof body === 'string' && meowCommand.test(body);
+}
+async function fetchCatImage() {
+    const headers = { accept: 'application/json' };
+    const key = core.getInput('cat-api-key', { required: false });
+    if (key !== '') {
+        core.setSecret(key);
+        headers['x-api-key'] = key;
+    }
+    let lastError = new Error('cat api was not reached');
+    for (let attempt = 1; attempt <= exports.meowConfig.maxAttempts; attempt++) {
+        if (attempt > 1)
+            await delay(exports.meowConfig.retryDelayMs);
+        try {
+            const response = await fetch(catApi, {
+                headers,
+                // refuse redirects so the api key cannot leak cross-origin
+                redirect: 'manual',
+                signal: AbortSignal.timeout(exports.meowConfig.timeoutMs),
+            });
+            if (response.ok && response.type !== 'opaqueredirect')
+                return parseCatImage(await response.json());
+            // undici holds the socket until the body is read
+            await cancelResponseBody(response);
+            // retry a 5xx; a 429, a redirect, and other 4xx fall back
+            const error = new Error(`cat api responded with ${response.status || 'a redirect'}`);
+            if (response.status >= 500) {
+                lastError = error;
+                continue;
+            }
+            throw error;
+        }
+        catch (error) {
+            // retry a network failure; a timeout has spent its deadline
+            if (!(error instanceof TypeError))
+                throw error;
+            lastError = error;
+        }
+    }
+    throw lastError;
+}
+async function cancelResponseBody(response) {
+    try {
+        await response.body?.cancel();
+    }
+    catch (error) {
+        core.debug(`could not cancel cat api response body: ${error}`);
+    }
+}
+// parseCatImage validates the response and returns a usable https url
+function parseCatImage(value) {
+    const images = value;
+    if (!Array.isArray(images) || images.length === 0)
+        throw new Error('cat api returned no images');
+    const url = images[0]?.url;
+    if (typeof url !== 'string')
+        throw new Error('cat api returned an invalid image record');
+    if (url.length > 4096)
+        throw new Error('cat api returned an excessively long image url');
+    let image;
+    try {
+        image = new URL(url);
+    }
+    catch {
+        throw new Error('cat api returned an invalid image url');
+    }
+    if (image.protocol !== 'https:'
+        || image.username !== ''
+        || image.password !== '') {
+        throw new Error('cat api returned an unusable image url');
+    }
+    return image;
+}
+function delay(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
 }
 
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,7 @@ Commands | Policy | Description
 `/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason
 `/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone
 `/retitle some new title` | Collaborators | Renames the issue / PR
+`/meow` | anyone | replies with a random cat image from [the cat API](https://thecatapi.com)
 
 Label Commands | Policy | Description
 --- | --- | ---
@@ -24,6 +25,32 @@ Label Commands | Policy | Description
 `/hold cancel` | anyone | removes the `hold` label
 `/priority [label1 label2 ...]` | anyone | adds a priority/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./automatic-merging.md)
 `/remove [label1 label2 ...]` | Collaborators | removes a specified label(s) on an issue / PR
+
+## Enabling `/meow`
+
+`/meow` is opt in and calls a third party image provider ([the cat API](https://thecatapi.com)). Anyone who can comment on the repository can invoke it and consume the configured API quota, and the command must be on its own line. It is best effort: if the provider is unavailable it leaves a short note instead of failing the workflow.
+
+```yaml
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  prow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          prow-commands: /meow
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          cat-api-key: '${{ secrets.CAT_API_KEY }}'
+```
+
+The workflow token needs `issues: write` or `pull-requests: write` to post the response, because a new repository's `GITHUB_TOKEN` often defaults to read only. Grant both when the same workflow handles comments on issues and pull requests.
+
+The `@v2` ref is a floating tag the maintainers move per release. `/meow` ships in the next `v2.x` release, so this example applies once that release is published and the `v2` tag points at it; until then, pin to the release that includes it.
+
+The API key is optional; unauthenticated access is best effort and may be rate limited by the provider. When set, it is provided from a repository secret and registered for runner masking before use, and is never intentionally included in the request URL or a GitHub comment.
 
 ## OWNERS
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ Label Commands | Policy | Description
 
 ## Enabling `/meow`
 
-`/meow` is opt in and calls a third party image provider ([the cat API](https://thecatapi.com)). Anyone who can comment on the repository can invoke it and consume the configured API quota, and the command must be on its own line. It is best effort: if the provider is unavailable it leaves a short note instead of failing the workflow.
+`/meow` is opt in and calls a third party image provider ([the cat API](https://thecatapi.com)). Anyone who can comment on the repository can invoke it and consume the configured API quota, so enable it only on repositories where that is acceptable. The command must be on its own line. It is best effort: if the provider is unavailable it leaves a short note instead of failing the workflow. Only images served from the provider's own CDN are rendered.
 
 ```yaml
 permissions:
@@ -47,8 +47,6 @@ jobs:
 ```
 
 The workflow token needs `issues: write` or `pull-requests: write` to post the response, because a new repository's `GITHUB_TOKEN` often defaults to read only. Grant both when the same workflow handles comments on issues and pull requests.
-
-The `@v2` ref is a floating tag the maintainers move per release. `/meow` ships in the next `v2.x` release, so this example applies once that release is published and the `v2` tag points at it; until then, pin to the release that includes it.
 
 The API key is optional; unauthenticated access is best effort and may be rate limited by the provider. When set, it is provided from a repository secret and registered for runner masking before use, and is never intentionally included in the request URL or a GitHub comment.
 

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -14,6 +14,7 @@ import { assign } from './assign'
 import { cc } from './cc'
 import { close } from './close'
 import { lock } from './lock'
+import { meow } from './meow'
 import { milestone } from './milestone'
 import { reopen } from './reopen'
 import { retitle } from './retitle'
@@ -85,6 +86,9 @@ export async function handleIssueComment(context: Context = github.context): Pro
 
           case '/milestone':
             return await milestone(context).catch(normalizeError)
+
+          case '/meow':
+            return await meow(context).catch(normalizeError)
 
           case '':
             return new Error(

--- a/src/issueComment/meow.ts
+++ b/src/issueComment/meow.ts
@@ -1,0 +1,151 @@
+import type { Context } from '@actions/github/lib/context'
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+
+import { Octokit } from '@octokit/rest'
+
+import { createComment } from '../utils/comments'
+
+const catApi = 'https://api.thecatapi.com/v1/images/search?limit=1&size=med'
+
+// a line of exactly /meow, not /meowvie or a mention
+const meowCommand = /^[\t ]*\/meow[\t ]*$/m
+
+// bounded so a slow provider cannot stall the runner; exported so tests can shrink the waits
+export const meowConfig = {
+  timeoutMs: 5_000,
+  maxAttempts: 3,
+  retryDelayMs: 500,
+}
+
+/**
+ * /meow replies with a random cat image
+ *
+ * @param context - the github actions event context
+ */
+export async function meow(context: Context = github.context): Promise<void> {
+  if (!hasMeowCommand(context.payload.comment?.body))
+    return
+
+  const token = core.getInput('github-token', { required: true })
+  const octokit = new Octokit({ auth: token })
+
+  const issueNumber: number | undefined = context.payload.issue?.number
+  if (issueNumber === undefined) {
+    throw new Error(
+      `github context payload missing issue number: ${context.payload}`,
+    )
+  }
+
+  // a provider outage degrades to a note; only the github write can fail the action
+  let body: string
+  try {
+    const image = await fetchCatImage()
+    body = `![cat](<${image.href}>)`
+  }
+  catch (error) {
+    core.warning(`Could not fetch a cat image: ${error}`)
+    body = 'The cat API is unavailable right now.'
+  }
+
+  await createComment(octokit, context, issueNumber, body)
+}
+
+// hasMeowCommand reports whether the body has a standalone /meow line
+function hasMeowCommand(body: unknown): boolean {
+  return typeof body === 'string' && meowCommand.test(body)
+}
+
+async function fetchCatImage(): Promise<URL> {
+  const headers: Record<string, string> = { accept: 'application/json' }
+  const key = core.getInput('cat-api-key', { required: false })
+  if (key !== '') {
+    core.setSecret(key)
+    headers['x-api-key'] = key
+  }
+
+  let lastError: unknown = new Error('cat api was not reached')
+  for (let attempt = 1; attempt <= meowConfig.maxAttempts; attempt++) {
+    if (attempt > 1)
+      await delay(meowConfig.retryDelayMs)
+
+    try {
+      const response = await fetch(catApi, {
+        headers,
+        // refuse redirects so the api key cannot leak cross-origin
+        redirect: 'manual',
+        signal: AbortSignal.timeout(meowConfig.timeoutMs),
+      })
+
+      if (response.ok && response.type !== 'opaqueredirect')
+        return parseCatImage(await response.json())
+
+      // undici holds the socket until the body is read
+      await cancelResponseBody(response)
+
+      // retry a 5xx; a 429, a redirect, and other 4xx fall back
+      const error = new Error(
+        `cat api responded with ${response.status || 'a redirect'}`,
+      )
+      if (response.status >= 500) {
+        lastError = error
+        continue
+      }
+      throw error
+    }
+    catch (error) {
+      // retry a network failure; a timeout has spent its deadline
+      if (!(error instanceof TypeError))
+        throw error
+      lastError = error
+    }
+  }
+
+  throw lastError
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel()
+  }
+  catch (error) {
+    core.debug(`could not cancel cat api response body: ${error}`)
+  }
+}
+
+// parseCatImage validates the response and returns a usable https url
+function parseCatImage(value: unknown): URL {
+  const images = value as Array<{ url?: unknown }>
+  if (!Array.isArray(images) || images.length === 0)
+    throw new Error('cat api returned no images')
+
+  const url = images[0]?.url
+  if (typeof url !== 'string')
+    throw new Error('cat api returned an invalid image record')
+  if (url.length > 4096)
+    throw new Error('cat api returned an excessively long image url')
+
+  let image: URL
+  try {
+    image = new URL(url)
+  }
+  catch {
+    throw new Error('cat api returned an invalid image url')
+  }
+
+  if (
+    image.protocol !== 'https:'
+    || image.username !== ''
+    || image.password !== ''
+  ) {
+    throw new Error('cat api returned an unusable image url')
+  }
+
+  return image
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/src/issueComment/meow.ts
+++ b/src/issueComment/meow.ts
@@ -141,7 +141,20 @@ function parseCatImage(value: unknown): URL {
     throw new Error('cat api returned an unusable image url')
   }
 
+  if (!isTrustedImageSource(image))
+    throw new Error('cat api returned an image from an unexpected host')
+
   return image
+}
+
+// only render images the provider actually serves; a compromised or spoofed
+// api response must not be able to embed an arbitrary third-party url
+function isTrustedImageSource(image: URL): boolean {
+  if (image.hostname === 'cdn2.thecatapi.com')
+    return true
+
+  return image.hostname === 's3.us-west-2.amazonaws.com'
+    && image.pathname.startsWith('/cdn2.thecatapi.com/')
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
# Description

Adds a `/meow` command that replies with a random cat image, requested in #78.

It matches only a standalone `/meow` line, so `/meowvie` (a real upstream command) and prose or urls that merely mention `/meow` do not trigger it. The image is fetched from [the cat API](https://thecatapi.com) with the global `fetch`, so it adds no dependencies, and is posted through the existing `createComment` helper, following the shape of the other issue comment commands.

Closes #78

## Behavior

- **Exact command match.** The central dispatcher matches commands by substring, so `/meow` alone would also fire on `/meowvie`, `/meow-debug`, and text like `please run /meow`. The command guards itself with `/^[\t ]*\/meow[\t ]*$/m` and returns early otherwise. Reworking the shared command parser is out of scope here.
- **Bounded external call.** Each attempt has a 5s `AbortSignal.timeout` and the command retries at most three times, only for a network failure or a 5xx. Timeout errors, 429 responses, other 4xx responses, invalid responses, and the GitHub write are not retried; retryable network failures and 5xx responses can each consume up to their own per-attempt deadline, so the total wall-clock time is bounded by the attempt count rather than a single deadline. A 429 is a rate limit, so it falls back rather than sending the same request again. Every non-2xx response has its body cancelled before the retry or fallback, so undici releases the connection instead of leaving it for the garbage collector.
- **Validated response.** `parseCatImage` checks the payload is a non-empty array whose first `url` is a string, bounds its length, parses it with `new URL`, and requires `https` with no embedded credentials. The url is embedded with the angle bracket form `![cat](<...>)` on the normalized href, so a parenthesis or other reserved character in a valid url renders correctly and an unexpected response cannot break out of the image.
- **Graceful degradation.** `/meow` is enabled per repository and open to anyone, so a cat API outage should not turn a repository's workflow red. A failed fetch logs `core.warning` and leaves a short note; only a failed GitHub comment write fails the Action.
- **Optional API key.** An optional `cat-api-key` input is sent as the `x-api-key` header when set, with `redirect: 'manual'` so a redirect is refused rather than followed and the header cannot reach another origin. Anonymous requests are best effort and share a rate limit. The key comes from a repository secret and is registered with `core.setSecret` for runner masking before the request, and is never intentionally included in the request URL or a GitHub comment.

## Scope

This intentionally implements only the bare `/meow` command. `/meowvie` and category arguments (`/meow <category>`) remain out of scope. The exact matching is a correctness fix rather than an enhancement, since without it `/meowvie` is wrongly executed as `/meow`. Command detection otherwise inherits the existing substring dispatcher, so a `/meow` line inside a code fence is still matched like any other command; reworking that shared parser is out of scope here. Issue #66 tracks ignoring code blocks and #81 tracks multi-command parsing behavior, and both apply to every command rather than being specific to `/meow`, so this change does not close either. Because `/meow` calls a third party and anyone can invoke it, it is kept out of the default Quickstart command list and documented as an opt-in command with its own example in the commands docs; enabling it in this repository's own workflow is left as a follow-up for the maintainers. This touches the same dispatch switch as #103, so if #103 merges first this rebases onto it, keeping every `.catch(normalizeError)` and adding the `/meow` case, with `dist/index.js` regenerated from a clean install rather than hand-merged. That regeneration also brings the bundled transitive `brace-expansion` in sync with the unchanged lockfile; no dependency versions changed.

# Testing

- [x] `npm run all` passes (build, lint, pack, test): 106 passing, 6 skipped
- [x] `meow.test.ts` runs with `onUnhandledRequest: 'error'` so a missed mock cannot reach the live cat API or GitHub, and spies `createComment` so no real write escapes
- [x] covers a standalone `/meow`, a url with parentheses, the four forms that must not trigger it (`/meowvie`, `/meow-debug`, `/meow cat`, prose), a CRLF comment where the standalone `/meow` still matches exactly once, a transient retry then success, a network error retried to the attempt limit, a persistent failure over three attempts, a rate limit that is not retried, a timeout that is not retried, an empty response, a first item without a url, an unparseable url, an over-length url, a non-https url, a credential url, a refused redirect that is not followed, a response body cancelled on both a retry and a non-retry, the request query, the API key header both set and absent, the key registered for masking, and a failed GitHub write that fails the Action
- [x] confirmed those four cases fail when the standalone guard is removed

# Checklist:

- [x] I ran `npm run all` to lint and build my code
- [x] No new dependencies
- [x] I have performed a self review of my own code
- [x] I have commented my code, particularly in hard to understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
