### PR TITLE
fix: fail on real label removal errors

### DIFF
--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
 
@@ -13,7 +14,10 @@ beforeAll(() =>
     onUnhandledRequest: 'warn',
   }),
 )
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  jest.restoreAllMocks()
+})
 afterAll(() => server.close())
 
 describe('hold', () => {
@@ -70,5 +74,38 @@ describe('hold', () => {
     await handleIssueComment(commentContext)
     await expect(observeReqDelete.called()).resolves.toBe('called')
     await expect(observeReqGet.called()).resolves.toBe('called')
+  })
+
+  it('fails the action when the hold removal fails', async () => {
+    issueCommentEvent.comment.body = '/hold cancel'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
+      id: 2,
+      node_id: '456',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/hold',
+      name: 'hold',
+      description: '',
+      color: 'f29513',
+      default: true,
+    })
+
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(500),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+    )
+
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not remove label hold'),
+    )
   })
 })

--- a/__tests__/label/remove.test.ts
+++ b/__tests__/label/remove.test.ts
@@ -14,7 +14,10 @@ beforeAll(() =>
     onUnhandledRequest: 'warn',
   }),
 )
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  jest.restoreAllMocks()
+})
 afterAll(() => server.close())
 
 describe('remove', () => {
@@ -92,5 +95,55 @@ describe('remove', () => {
     const spy = jest.spyOn(core, 'setFailed')
     await handleIssueComment(commentContext)
     expect(spy).toHaveBeenCalled()
+  })
+
+  it('fails the action when a label removal fails', async () => {
+    issueCommentEvent.comment.body = '/remove some-label'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(500),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not remove label some-label'),
+    )
+  })
+
+  it('ignores a label that is already gone', async () => {
+    issueCommentEvent.comment.body = '/remove some-label'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/some-label`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const setFailed = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -3035,7 +3035,11 @@ async function removeLabels(octokit, context, issueNum, labels) {
             });
         }
         catch (e) {
-            core.debug(`could not remove labels: ${e}`);
+            // a gone label is a benign race; anything else is a real failure
+            if (isNotFound(e))
+                core.debug(`label ${label} was already absent: ${e}`);
+            else
+                throw new Error(`could not remove label ${label}: ${e}`);
         }
     }
 }
@@ -3080,6 +3084,13 @@ async function cancelLabel(octokit, context, issueNum, label) {
     else {
         core.debug(`could not find ${label} to remove`);
     }
+}
+// isNotFound reports whether an octokit error is a 404
+function isNotFound(error) {
+    return (typeof error === 'object'
+        && error !== null
+        && 'status' in error
+        && error.status === 404);
 }
 
 

--- a/src/utils/labeling.ts
+++ b/src/utils/labeling.ts
@@ -143,7 +143,11 @@ export async function removeLabels(
       })
     }
     catch (e) {
-      core.debug(`could not remove labels: ${e}`)
+      // a gone label is a benign race; anything else is a real failure
+      if (isNotFound(e))
+        core.debug(`label ${label} was already absent: ${e}`)
+      else
+        throw new Error(`could not remove label ${label}: ${e}`)
     }
   }
 }
@@ -198,4 +202,14 @@ export async function cancelLabel(
   else {
     core.debug(`could not find ${label} to remove`)
   }
+}
+
+// isNotFound reports whether an octokit error is a 404
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object'
+    && error !== null
+    && 'status' in error
+    && error.status === 404
+  )
 }


### PR DESCRIPTION
# Description

`removeLabels()` caught every error from `octokit.issues.removeLabel` and only logged it with `core.debug`, so `/remove`, `/hold cancel`, and `/lgtm cancel` reported success even when the removal failed with a 403, a 500, or a network error, leaving the label in place.

This keeps the benign case quiet and surfaces the rest: a 404 means the label is already gone, so it stays a debug log, but any other error is rethrown. The callers `cancelLabel` and `remove` already propagate, so a real failure now reaches `core.setFailed`.

Fixes #105

# Testing

- [x] `npm run all` passes (build, lint, pack, test)
- [x] a failing removal (500) fails the Action through `core.setFailed`, via `/remove` and via the `/hold cancel` path through `cancelLabel`
- [x] a label that is already gone (404) is ignored and the Action still succeeds
- [x] confirmed the failure test fails without the change

# Checklist:

- [x] I ran `npm run all` to lint and build my code
- [x] No new dependencies
- [x] I have performed a self review of my own code
- [x] I have commented my code, particularly in hard to understand areas
- [ ] I have made corresponding changes to the documentation (no documentation changes needed)
- [x] My changes generate no new warnings
