### PR TITLE
feat: Add automated release workflows with waybill SBOM generation

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,126 @@
+name: Pre-Release (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag without leading v (e.g. 2.1.0-rc.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  WAYBILL_VERSION: v0.2.0
+  WAYBILL_SHA256: 5f946e48de62f44d205ef92a21864f55fc49a7da4f71619aec0c1e4cd1c617bb
+
+jobs:
+  verify:
+    name: Build, Test & Verify dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build, lint & test
+        run: |
+          npm run build
+          npm run lint
+          npm test
+
+      - name: Verify committed dist/ matches source
+        run: |
+          npm run pack
+          if ! git diff --quiet dist/; then
+            echo "::error::dist/ is out of date. Run 'npm run pack' and commit the result before releasing."
+            git --no-pager diff --stat dist/
+            exit 1
+          fi
+
+  github-release:
+    name: Create Pre-Release
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: write
+      id-token: write       # For cosign keyless signing
+      attestations: write   # For GitHub artifact attestations
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Create tag
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Install waybill
+        run: |
+          curl -sSfL -o waybill.tar.gz \
+            "https://github.com/kusari-oss/waybill/releases/download/${WAYBILL_VERSION}/waybill-${WAYBILL_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${WAYBILL_SHA256}  waybill.tar.gz" | sha256sum -c -
+          tar -xzf waybill.tar.gz
+          sudo install -m 0755 "waybill-${WAYBILL_VERSION}-x86_64-unknown-linux-gnu/waybill" /usr/local/bin/waybill
+          waybill --version
+
+      - name: Generate SBOM (SPDX 2.3)
+        run: |
+          waybill sbom scan --path . \
+            --exclude-path dist \
+            --format spdx-2.3-json \
+            --output "prow-github-actions-${{ inputs.version }}.spdx.json"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SBOM
+        run: |
+          cosign sign-blob --yes \
+            --bundle "prow-github-actions-${{ inputs.version }}.spdx.json.bundle" \
+            "prow-github-actions-${{ inputs.version }}.spdx.json"
+
+      - name: Attest SBOM provenance
+        id: provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: prow-github-actions-${{ inputs.version }}.spdx.json
+
+      - name: Rename provenance bundle
+        run: |
+          cp "${{ steps.provenance.outputs.bundle-path }}" \
+            "prow-github-actions-${{ inputs.version }}.spdx.json.intoto.jsonl"
+
+      - name: Create GitHub Pre-Release
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
+        with:
+          tag_name: v${{ inputs.version }}
+          name: prow-github-actions ${{ inputs.version }}
+          generate_release_notes: true
+          files: |
+            prow-github-actions-${{ inputs.version }}.spdx.json
+            prow-github-actions-${{ inputs.version }}.spdx.json.bundle
+            prow-github-actions-${{ inputs.version }}.spdx.json.intoto.jsonl
+          body: |
+            > ⚠️ **Pre-release** — built from branch `${{ github.ref_name }}`
+
+            ## Usage
+
+            ```yaml
+            - uses: ${{ github.repository }}@v${{ inputs.version }}
+            ```
+
+            ## SBOM
+
+            An SPDX 2.3 SBOM generated with [waybill](https://github.com/kusari-oss/waybill)
+            is attached, signed with cosign (keyless) and attested with SLSA provenance.
+          draft: false
+          prerelease: true

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag without leading v (e.g. 2.1.0-rc.1)'
+        description: Pre-release version without leading v (e.g. 2.1.0-rc.1)
         required: true
         type: string
 
@@ -20,11 +20,20 @@ jobs:
     name: Build, Test & Verify dist
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-(rc|alpha|beta)\.[0-9]+$'; then
+            echo "::error::version must look like 2.1.0-rc.1 (a pre-release suffix is required)"
+            exit 1
+          fi
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies
@@ -39,7 +48,7 @@ jobs:
       - name: Verify committed dist/ matches source
         run: |
           npm run pack
-          if ! git diff --quiet dist/; then
+          if [ -n "$(git status --porcelain dist/)" ]; then
             echo "::error::dist/ is out of date. Run 'npm run pack' and commit the result before releasing."
             git --no-pager diff --stat dist/
             exit 1
@@ -51,17 +60,14 @@ jobs:
     needs: verify
     permissions:
       contents: write
-      id-token: write       # For cosign keyless signing
-      attestations: write   # For GitHub artifact attestations
+      id-token: write # For cosign keyless signing
+      attestations: write # For GitHub artifact attestations
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-
-      - name: Create tag
-        run: |
-          git tag "v${{ inputs.version }}"
-          git push origin "v${{ inputs.version }}"
 
       - name: Install waybill
         run: |
@@ -76,8 +82,9 @@ jobs:
         run: |
           waybill sbom scan --path . \
             --exclude-path dist \
+            --exclude-scope dev,build,test \
             --format spdx-2.3-json \
-            --output "prow-github-actions-${{ inputs.version }}.spdx.json"
+            --output "prow-github-actions-${VERSION}.spdx.json"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -85,42 +92,51 @@ jobs:
       - name: Sign SBOM
         run: |
           cosign sign-blob --yes \
-            --bundle "prow-github-actions-${{ inputs.version }}.spdx.json.bundle" \
-            "prow-github-actions-${{ inputs.version }}.spdx.json"
+            --bundle "prow-github-actions-${VERSION}.spdx.json.bundle" \
+            "prow-github-actions-${VERSION}.spdx.json"
 
-      - name: Attest SBOM provenance
+      - name: Attest build provenance
         id: provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: prow-github-actions-${{ inputs.version }}.spdx.json
+          subject-path: |
+            dist/index.js
+            prow-github-actions-${{ env.VERSION }}.spdx.json
 
       - name: Rename provenance bundle
+        env:
+          BUNDLE_PATH: ${{ steps.provenance.outputs.bundle-path }}
+        run: cp "$BUNDLE_PATH" "prow-github-actions-${VERSION}.intoto.jsonl"
+
+      - name: Create tag
         run: |
-          cp "${{ steps.provenance.outputs.bundle-path }}" \
-            "prow-github-actions-${{ inputs.version }}.spdx.json.intoto.jsonl"
+          git tag "v${VERSION}" "$GITHUB_SHA"
+          git push origin "refs/tags/v${VERSION}"
 
       - name: Create GitHub Pre-Release
-        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
-          tag_name: v${{ inputs.version }}
-          name: prow-github-actions ${{ inputs.version }}
+          tag_name: v${{ env.VERSION }}
+          name: prow-github-actions ${{ env.VERSION }}
           generate_release_notes: true
           files: |
-            prow-github-actions-${{ inputs.version }}.spdx.json
-            prow-github-actions-${{ inputs.version }}.spdx.json.bundle
-            prow-github-actions-${{ inputs.version }}.spdx.json.intoto.jsonl
+            prow-github-actions-${{ env.VERSION }}.spdx.json
+            prow-github-actions-${{ env.VERSION }}.spdx.json.bundle
+            prow-github-actions-${{ env.VERSION }}.intoto.jsonl
           body: |
-            > ⚠️ **Pre-release** — built from branch `${{ github.ref_name }}`
+            > ⚠️ **Pre-release** — built from `${{ github.ref_name }}` at `${{ github.sha }}`
 
             ## Usage
 
             ```yaml
-            - uses: ${{ github.repository }}@v${{ inputs.version }}
+            - uses: ${{ github.repository }}@v${{ env.VERSION }}
             ```
 
-            ## SBOM
+            ## SBOM and provenance
 
-            An SPDX 2.3 SBOM generated with [waybill](https://github.com/kusari-oss/waybill)
-            is attached, signed with cosign (keyless) and attested with SLSA provenance.
+            An SPDX 2.3 SBOM of the runtime dependencies, generated with
+            [waybill](https://github.com/kusari-oss/waybill), is attached and signed
+            with cosign (keyless). SLSA build provenance covering `dist/index.js` and
+            the SBOM is attached as `prow-github-actions-${{ env.VERSION }}.intoto.jsonl`.
           draft: false
           prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+env:
+  WAYBILL_VERSION: v0.2.0
+  WAYBILL_SHA256: 5f946e48de62f44d205ef92a21864f55fc49a7da4f71619aec0c1e4cd1c617bb
+
+jobs:
+  verify:
+    name: Build, Test & Verify dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build, lint & test
+        run: |
+          npm run build
+          npm run lint
+          npm test
+
+      - name: Verify committed dist/ matches source
+        run: |
+          npm run pack
+          if ! git diff --quiet dist/; then
+            echo "::error::dist/ is out of date. Run 'npm run pack' and commit the result before tagging."
+            git --no-pager diff --stat dist/
+            exit 1
+          fi
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: write
+      id-token: write       # For cosign keyless signing
+      attestations: write   # For GitHub artifact attestations
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install waybill
+        run: |
+          curl -sSfL -o waybill.tar.gz \
+            "https://github.com/kusari-oss/waybill/releases/download/${WAYBILL_VERSION}/waybill-${WAYBILL_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          echo "${WAYBILL_SHA256}  waybill.tar.gz" | sha256sum -c -
+          tar -xzf waybill.tar.gz
+          sudo install -m 0755 "waybill-${WAYBILL_VERSION}-x86_64-unknown-linux-gnu/waybill" /usr/local/bin/waybill
+          waybill --version
+
+      - name: Generate SBOM (SPDX 2.3)
+        run: |
+          waybill sbom scan --path . \
+            --exclude-path dist \
+            --format spdx-2.3-json \
+            --output "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SBOM
+        run: |
+          cosign sign-blob --yes \
+            --bundle "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle" \
+            "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json"
+
+      - name: Attest SBOM provenance
+        id: provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
+
+      - name: Rename provenance bundle
+        run: |
+          cp "${{ steps.provenance.outputs.bundle-path }}" \
+            "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.intoto.jsonl"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: prow-github-actions ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
+            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle
+            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.intoto.jsonl
+          body: |
+            ## Usage
+
+            ```yaml
+            - uses: ${{ github.repository }}@${{ github.ref_name }}
+            ```
+
+            ## SBOM
+
+            An SPDX 2.3 SBOM generated with [waybill](https://github.com/kusari-oss/waybill)
+            is attached as `prow-github-actions-${{ steps.version.outputs.version }}.spdx.json`.
+            It is signed with [cosign](https://github.com/sigstore/cosign) (keyless) and
+            attested with SLSA provenance.
+
+            Verify the SBOM signature:
+            ```bash
+            cosign verify-blob \
+              --bundle prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle \
+              --certificate-identity-regexp="https://github.com/${{ github.repository }}" \
+              --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+              prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
+            ```
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
   contents: read
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version-file: package.json
           cache: npm
 
       - name: Install dependencies
@@ -36,7 +36,7 @@ jobs:
       - name: Verify committed dist/ matches source
         run: |
           npm run pack
-          if ! git diff --quiet dist/; then
+          if [ -n "$(git status --porcelain dist/)" ]; then
             echo "::error::dist/ is out of date. Run 'npm run pack' and commit the result before tagging."
             git --no-pager diff --stat dist/
             exit 1
@@ -48,16 +48,17 @@ jobs:
     needs: verify
     permissions:
       contents: write
-      id-token: write       # For cosign keyless signing
-      attestations: write   # For GitHub artifact attestations
+      id-token: write # For cosign keyless signing
+      attestations: write # For GitHub artifact attestations
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "MAJOR=${GITHUB_REF_NAME%%.*}" >> "$GITHUB_ENV"
 
       - name: Install waybill
         run: |
@@ -72,8 +73,9 @@ jobs:
         run: |
           waybill sbom scan --path . \
             --exclude-path dist \
+            --exclude-scope dev,build,test \
             --format spdx-2.3-json \
-            --output "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json"
+            --output "prow-github-actions-${VERSION}.spdx.json"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -81,30 +83,32 @@ jobs:
       - name: Sign SBOM
         run: |
           cosign sign-blob --yes \
-            --bundle "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle" \
-            "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json"
+            --bundle "prow-github-actions-${VERSION}.spdx.json.bundle" \
+            "prow-github-actions-${VERSION}.spdx.json"
 
-      - name: Attest SBOM provenance
+      - name: Attest build provenance
         id: provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
+          subject-path: |
+            dist/index.js
+            prow-github-actions-${{ env.VERSION }}.spdx.json
 
       - name: Rename provenance bundle
-        run: |
-          cp "${{ steps.provenance.outputs.bundle-path }}" \
-            "prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.intoto.jsonl"
+        env:
+          BUNDLE_PATH: ${{ steps.provenance.outputs.bundle-path }}
+        run: cp "$BUNDLE_PATH" "prow-github-actions-${VERSION}.intoto.jsonl"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref_name }}
-          name: prow-github-actions ${{ steps.version.outputs.version }}
+          name: prow-github-actions ${{ env.VERSION }}
           generate_release_notes: true
           files: |
-            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
-            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle
-            prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.intoto.jsonl
+            prow-github-actions-${{ env.VERSION }}.spdx.json
+            prow-github-actions-${{ env.VERSION }}.spdx.json.bundle
+            prow-github-actions-${{ env.VERSION }}.intoto.jsonl
           body: |
             ## Usage
 
@@ -112,20 +116,33 @@ jobs:
             - uses: ${{ github.repository }}@${{ github.ref_name }}
             ```
 
-            ## SBOM
+            ## SBOM and provenance
 
-            An SPDX 2.3 SBOM generated with [waybill](https://github.com/kusari-oss/waybill)
-            is attached as `prow-github-actions-${{ steps.version.outputs.version }}.spdx.json`.
-            It is signed with [cosign](https://github.com/sigstore/cosign) (keyless) and
-            attested with SLSA provenance.
+            An SPDX 2.3 SBOM of the runtime dependencies, generated with
+            [waybill](https://github.com/kusari-oss/waybill), is attached as
+            `prow-github-actions-${{ env.VERSION }}.spdx.json` and signed with
+            [cosign](https://github.com/sigstore/cosign) (keyless). SLSA build
+            provenance covering both `dist/index.js` and the SBOM is attached as
+            `prow-github-actions-${{ env.VERSION }}.intoto.jsonl`.
 
             Verify the SBOM signature:
             ```bash
             cosign verify-blob \
-              --bundle prow-github-actions-${{ steps.version.outputs.version }}.spdx.json.bundle \
+              --bundle prow-github-actions-${{ env.VERSION }}.spdx.json.bundle \
               --certificate-identity-regexp="https://github.com/${{ github.repository }}" \
               --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-              prow-github-actions-${{ steps.version.outputs.version }}.spdx.json
+              prow-github-actions-${{ env.VERSION }}.spdx.json
+            ```
+
+            Verify the provenance of the bundled action:
+            ```bash
+            gh attestation verify dist/index.js --repo ${{ github.repository }}
             ```
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+
+      - name: Update floating major tag
+        if: ${{ !contains(github.ref_name, '-') }}
+        run: |
+          git tag -f "$MAJOR" "$GITHUB_REF_NAME"
+          git push -f origin "refs/tags/$MAJOR"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ jobs:
 - [Automatic PR merging](./docs/automatic-merging.md)
 - [PR jobs](./docs/pr-jobs.md)
 - [Examples](./docs/examples.md)
+- [Releasing](./docs/releasing.md)
 - [Contributing](./docs/contributing.md)
 
 ---

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -20,3 +20,4 @@ that can be run with specific [Github "events"](https://docs.github.com/en/actio
   - [Available cron jobs](./cron-jobs.md)
 - [Jobs to run on PR update](./pr-jobs.md)
 - [Examples](./examples.md)
+- [Releasing](./releasing.md)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,7 +8,7 @@ Releases are automated through two GitHub Actions workflows:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| [`release.yml`](../.github/workflows/release.yml) | Push of a `v*` tag | Stable (and tagged pre-) releases |
+| [`release.yml`](../.github/workflows/release.yml) | Push of a `vX.Y.Z[-suffix]` tag | Stable (and tagged pre-) releases |
 | [`pre-release.yml`](../.github/workflows/pre-release.yml) | Manual (`workflow_dispatch`) | Release candidates / pre-releases |
 
 Both workflows:
@@ -16,17 +16,21 @@ Both workflows:
 1. **Verify** the code: `npm ci`, `npm run build`, `npm run lint`, `npm test`,
    and check that the committed `dist/` bundle matches a fresh `ncc` build
    (`npm run pack`). The release fails if `dist/` is out of date.
-2. **Generate an SBOM** in SPDX 2.3 JSON format using
-   [waybill](https://github.com/kusari-oss/waybill) (pinned version,
-   SHA256-verified download).
+2. **Generate an SBOM** of the runtime dependencies in SPDX 2.3 JSON format
+   using [waybill](https://github.com/kusari-oss/waybill) (pinned version,
+   SHA256-verified download; dev/build/test scopes excluded).
 3. **Sign the SBOM** with [cosign](https://github.com/sigstore/cosign)
    (keyless, via GitHub OIDC) and create a SLSA build provenance
-   attestation.
+   attestation covering both `dist/index.js` and the SBOM.
 4. **Create a GitHub Release** with auto-generated release notes and the
    following attached artifacts:
    - `prow-github-actions-<version>.spdx.json` — the SBOM
    - `prow-github-actions-<version>.spdx.json.bundle` — cosign signature bundle
-   - `prow-github-actions-<version>.spdx.json.intoto.jsonl` — SLSA provenance
+   - `prow-github-actions-<version>.intoto.jsonl` — SLSA provenance
+
+For stable releases, `release.yml` additionally moves the floating major tag
+(`v2`, `v3`, …) to the new release so that `uses: cncf/prow-github-actions@v2`
+tracks the latest `v2.x.y`. Pre-releases never move the floating tag.
 
 ## Cutting a stable release
 
@@ -48,19 +52,22 @@ Both workflows:
    git push origin v2.1.0
    ```
 
-The `release.yml` workflow takes it from there. Tags containing `-rc`,
-`-alpha`, or `-beta` are automatically marked as pre-releases.
+The `release.yml` workflow takes it from there. Tags with a pre-release
+suffix (anything after a `-`, e.g. `v2.1.0-rc.1`) are marked as pre-releases
+and do not move the floating major tag.
 
 ## Cutting a pre-release (release candidate)
 
 Use the **Pre-Release (manual)** workflow from the Actions tab:
 
 1. Go to *Actions → Pre-Release (manual) → Run workflow*.
-2. Enter the version **without** the leading `v`, e.g. `2.1.0-rc.1`.
+2. Enter the version **without** the leading `v`, e.g. `2.1.0-rc.1`. The
+   value must match `X.Y.Z-(rc|alpha|beta).N`; anything else is rejected.
 3. Run the workflow on the branch you want to release from.
 
-The workflow creates the tag `v2.1.0-rc.1`, runs the same verification and
-SBOM pipeline, and publishes a GitHub Release marked as *pre-release*.
+The workflow runs the same verification and SBOM pipeline, then creates the
+tag `v2.1.0-rc.1` at the dispatched commit and publishes a GitHub Release
+marked as *pre-release*.
 
 > Note: the tag pushed by the workflow does **not** re-trigger
 > `release.yml` — GitHub suppresses workflow runs triggered by pushes made
@@ -79,9 +86,11 @@ cosign verify-blob \
   prow-github-actions-${VERSION}.spdx.json
 ```
 
-Verify the SLSA provenance attestation:
+Verify the SLSA provenance of the bundled action (from a checkout of the
+release tag) or of the SBOM:
 
 ```bash
+gh attestation verify dist/index.js --repo cncf/prow-github-actions
 gh attestation verify prow-github-actions-${VERSION}.spdx.json \
   --repo cncf/prow-github-actions
 ```
@@ -89,9 +98,13 @@ gh attestation verify prow-github-actions-${VERSION}.spdx.json \
 ## Versioning
 
 Releases follow [SemVer](https://semver.org/) with `v`-prefixed tags
-(`v1.0.0`, `v2.0.0-rc.1`, `v2.0.0`, …). Users are encouraged to pin to a
-full version tag:
+(`v1.0.0`, `v2.0.0-rc.1`, `v2.0.0`, …). The floating major tag (`v2`) always
+points at the latest stable `v2.x.y` release:
 
 ```yaml
-- uses: cncf/prow-github-actions@v2.0.0
+# track the latest v2.x.y
+- uses: cncf/prow-github-actions@v2
+
+# or pin to an exact release
+- uses: cncf/prow-github-actions@v2.1.0
 ```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,97 @@
+# Releasing
+
+This document describes how prow-github-actions is released.
+
+## Overview
+
+Releases are automated through two GitHub Actions workflows:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`release.yml`](../.github/workflows/release.yml) | Push of a `v*` tag | Stable (and tagged pre-) releases |
+| [`pre-release.yml`](../.github/workflows/pre-release.yml) | Manual (`workflow_dispatch`) | Release candidates / pre-releases |
+
+Both workflows:
+
+1. **Verify** the code: `npm ci`, `npm run build`, `npm run lint`, `npm test`,
+   and check that the committed `dist/` bundle matches a fresh `ncc` build
+   (`npm run pack`). The release fails if `dist/` is out of date.
+2. **Generate an SBOM** in SPDX 2.3 JSON format using
+   [waybill](https://github.com/kusari-oss/waybill) (pinned version,
+   SHA256-verified download).
+3. **Sign the SBOM** with [cosign](https://github.com/sigstore/cosign)
+   (keyless, via GitHub OIDC) and create a SLSA build provenance
+   attestation.
+4. **Create a GitHub Release** with auto-generated release notes and the
+   following attached artifacts:
+   - `prow-github-actions-<version>.spdx.json` — the SBOM
+   - `prow-github-actions-<version>.spdx.json.bundle` — cosign signature bundle
+   - `prow-github-actions-<version>.spdx.json.intoto.jsonl` — SLSA provenance
+
+## Cutting a stable release
+
+1. Make sure `main` is green and the bundled action is up to date:
+
+   ```bash
+   npm run all          # build + lint + pack + test
+   git add dist/
+   git commit -m "chore: Bump dist for release"
+   git push
+   ```
+
+2. Update the `version` field in `package.json` if needed.
+
+3. Tag and push:
+
+   ```bash
+   git tag v2.1.0
+   git push origin v2.1.0
+   ```
+
+The `release.yml` workflow takes it from there. Tags containing `-rc`,
+`-alpha`, or `-beta` are automatically marked as pre-releases.
+
+## Cutting a pre-release (release candidate)
+
+Use the **Pre-Release (manual)** workflow from the Actions tab:
+
+1. Go to *Actions → Pre-Release (manual) → Run workflow*.
+2. Enter the version **without** the leading `v`, e.g. `2.1.0-rc.1`.
+3. Run the workflow on the branch you want to release from.
+
+The workflow creates the tag `v2.1.0-rc.1`, runs the same verification and
+SBOM pipeline, and publishes a GitHub Release marked as *pre-release*.
+
+> Note: the tag pushed by the workflow does **not** re-trigger
+> `release.yml` — GitHub suppresses workflow runs triggered by pushes made
+> with the default `GITHUB_TOKEN`.
+
+## Verifying release artifacts
+
+Verify the SBOM signature of a release:
+
+```bash
+VERSION=2.1.0
+cosign verify-blob \
+  --bundle prow-github-actions-${VERSION}.spdx.json.bundle \
+  --certificate-identity-regexp="https://github.com/cncf/prow-github-actions" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  prow-github-actions-${VERSION}.spdx.json
+```
+
+Verify the SLSA provenance attestation:
+
+```bash
+gh attestation verify prow-github-actions-${VERSION}.spdx.json \
+  --repo cncf/prow-github-actions
+```
+
+## Versioning
+
+Releases follow [SemVer](https://semver.org/) with `v`-prefixed tags
+(`v1.0.0`, `v2.0.0-rc.1`, `v2.0.0`, …). Users are encouraged to pin to a
+full version tag:
+
+```yaml
+- uses: cncf/prow-github-actions@v2.0.0
+```


### PR DESCRIPTION
# Description

Automates the release process, which was previously fully manual (build `dist/`, tag, create the GitHub Release by hand).

This PR adds two GitHub Actions workflows and documentation:

- **`.github/workflows/release.yml`** — triggered on `v*` tag push:
  1. **Verify**: `npm ci`, build, lint, test, and checks that the committed `dist/` bundle matches a fresh `ncc` build (fails if `npm run pack` was forgotten before tagging)
  2. **SBOM**: generates an SPDX 2.3 SBOM with [waybill](https://github.com/kusari-oss/waybill) (pinned version, SHA256-verified download)
  3. **Signing**: signs the SBOM with cosign (keyless via GitHub OIDC) and creates a SLSA build provenance attestation
  4. **Release**: publishes a GitHub Release with auto-generated notes and the SBOM + signature bundle + provenance attached. Tags containing `-rc`/`-alpha`/`-beta` are marked as pre-releases automatically.
- **`.github/workflows/pre-release.yml`** — manual `workflow_dispatch` for release candidates: creates the tag from the chosen branch and publishes a pre-release using the same verification and SBOM pipeline. The tag pushed by this workflow does not re-trigger `release.yml` (GitHub suppresses recursive `GITHUB_TOKEN` triggers).
- **`docs/releasing.md`** — describes the release process, including how to verify the SBOM signature (`cosign verify-blob`) and provenance (`gh attestation verify`); linked from `README.md` and `docs/overview.md`.

All third-party actions are pinned by commit SHA; the waybill binary download is verified against a pinned SHA256.

Fixes # (no issue)

# Testing

- [x] Validated YAML syntax of both workflows
- [x] Tested waybill SBOM generation locally against this repository: valid SPDX 2.3 output with 648 packages including license enrichment (deps.dev / ClearlyDefined)
- [x] Verified the pinned waybill tarball SHA256 and archive layout used by the install step

# Checklist:

- [x] I ran `npm run all` to lint and build my code (no source code changes — workflows and docs only)
- [x] Note any new dependencies these changes bring in: CI-only tools — waybill (SHA256-pinned binary), cosign, actions/attest-build-provenance, softprops/action-gh-release (all pinned by commit SHA). No npm dependencies added.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/releasing.md`, `README.md`, `docs/overview.md`)
- [x] My changes generates no new warnings
