### PR TITLE
fix: parse commands with CRLF line endings

### DIFF
--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -1,4 +1,4 @@
-import { getCommandArgs } from '../../src/utils/command'
+import { getCommandArgs, getLineArgs } from '../../src/utils/command'
 
 it('handles comments with multiple lines', () => {
   const body = `Here is something
@@ -14,6 +14,19 @@ invalid`
   output = getCommandArgs('/another-comment', body)
 
   expect(output).toMatchObject(['arg3', 'arg4'])
+})
+
+it('handles a comment with CRLF line endings', () => {
+  const body = '/kind enhancement\r\n/milestone some title\r\n/area ai'
+
+  expect(getCommandArgs('/kind', body)).toMatchObject(['enhancement'])
+  expect(getCommandArgs('/area', body)).toMatchObject(['ai'])
+})
+
+it('does not leave a carriage return on a line argument', () => {
+  const body = '/milestone some title\r\n/area ai'
+
+  expect(getLineArgs('/milestone', body)).toBe('some title')
 })
 
 describe('strips at signs', () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2792,7 +2792,7 @@ exports.getCommandArgs = getCommandArgs;
  */
 function getLineArgs(command, body) {
     let toReturn = '';
-    const lineArray = body.split('\n');
+    const lineArray = splitLines(body);
     for (const iterator of lineArray) {
         if (iterator.includes(command)) {
             toReturn = iterator.replace(`${command} `, '');
@@ -2809,7 +2809,7 @@ function getLineArgs(command, body) {
  */
 function getCommandArgs(command, body) {
     const toReturn = [];
-    const lineArray = body.split('\n');
+    const lineArray = splitLines(body);
     let bodyArray;
     for (const iterator of lineArray) {
         if (iterator.includes(command)) {
@@ -2830,6 +2830,10 @@ function getCommandArgs(command, body) {
         i++;
     }
     return stripAtSign(toReturn);
+}
+// splitLines splits a comment body into lines, tolerating CRLF and CR endings
+function splitLines(body) {
+    return body.replace(/\r\n?/g, '\n').split('\n');
 }
 /**
  * stripAtSign will remove a leading '@' sign from the arguments array

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -7,7 +7,7 @@
  */
 export function getLineArgs(command: string, body: string): string {
   let toReturn = ''
-  const lineArray = body.split('\n')
+  const lineArray = splitLines(body)
 
   for (const iterator of lineArray) {
     if (iterator.includes(command)) {
@@ -27,7 +27,7 @@ export function getLineArgs(command: string, body: string): string {
  */
 export function getCommandArgs(command: string, body: string): string[] {
   const toReturn = []
-  const lineArray = body.split('\n')
+  const lineArray = splitLines(body)
   let bodyArray
 
   for (const iterator of lineArray) {
@@ -53,6 +53,11 @@ export function getCommandArgs(command: string, body: string): string[] {
   }
 
   return stripAtSign(toReturn)
+}
+
+// splitLines splits a comment body into lines, tolerating CRLF and CR endings
+function splitLines(body: string): string[] {
+  return body.replace(/\r\n?/g, '\n').split('\n')
 }
 
 /**


### PR DESCRIPTION
# Description

`getCommandArgs` and `getLineArgs` split the comment body on `\n` but never strip the `\r`, so with a CRLF comment every line except the last keeps a trailing carriage return. `/kind enhancement\r` is then filtered out because `enhancement\r` is not an allowed label, `/milestone ...\r` misses the milestone by name, and only the final line, which has no `\r`, works.

That is exactly #81: `/kind`, `/milestone`, and `/area` only took effect on whichever command was on the last line, and reordering changed which one worked. GitHub delivers comment bodies with CRLF, so this hits any comment with more than one command.

This normalizes `\r\n` and a lone `\r` to `\n` before splitting, through a small `splitLines` helper used by both functions.

Fixes #81

# Testing

- [x] `npm run all` passes (build, lint, pack, test)
- [x] a CRLF comment with `/kind` and `/area` returns each command's args without a trailing carriage return
- [x] `getLineArgs` returns a milestone title with no trailing carriage return
- [x] confirmed both tests fail without the change

# Checklist:

- [x] I ran `npm run all` to lint and build my code
- [x] No new dependencies
- [x] I have performed a self review of my own code
- [x] I have commented my code, particularly in hard to understand areas
- [ ] I have made corresponding changes to the documentation (no documentation changes needed)
- [x] My changes generate no new warnings
