### PR TITLE
chore(dependabot): ignore msw >= 2.11 until Jest can load ESM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # msw >= 2.11 depends on ESM-only packages that Jest 29 cannot load;
+      # lift this once the test runner supports ESM dependencies.
+      - dependency-name: msw
+        versions: ['>=2.11.0']
     groups:
       production-dependencies:
         dependency-type: production


### PR DESCRIPTION
Follow-up to #110. Dependabot immediately proposed msw 2.15 again (#120), which breaks the test suite: msw 2.11+ depends on ESM-only packages (`until-async`, `rettime`) that Jest 29's CJS runtime can't load. This adds an `ignore` rule so it isn't re-proposed until the Jest 30 / ESM migration.

No code changes.