### PR TITLE
test: fix locked-PR bug, harden test infrastructure, cover negative paths, gate coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run lint
-      - run: npm test
+      - run: npm run test:coverage
       - name: Verify committed dist/ matches source
         run: |
           npm run pack

--- a/__tests__/cronJobTest/handleCronJob.test.ts
+++ b/__tests__/cronJobTest/handleCronJob.test.ts
@@ -1,0 +1,33 @@
+import * as core from '@actions/core'
+import { describe, expect, it, vi } from 'vitest'
+
+import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
+import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
+
+import * as utils from '../testUtils'
+
+describe('handleCronJobs', () => {
+  it('fails when the job is not supported', async () => {
+    utils.setupJobsEnv('not-a-job')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.toBeUndefined()
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not execute not-a-job. May not be supported'),
+    )
+  })
+
+  it('fails when no jobs are configured', async () => {
+    utils.setupJobsEnv('')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.toBeUndefined()
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('please provide a list of space delimited commands / jobs to run'),
+    )
+  })
+})

--- a/__tests__/cronJobTest/labelPr.test.ts
+++ b/__tests__/cronJobTest/labelPr.test.ts
@@ -134,6 +134,6 @@ describe('cronLabelPr', () => {
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
-    expect(observeReq.ref).toBeNull()
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
   })
 })

--- a/__tests__/cronJobTest/labelPr.test.ts
+++ b/__tests__/cronJobTest/labelPr.test.ts
@@ -105,4 +105,35 @@ describe('cronLabelPr', () => {
       labels: ['tests'],
     })
   })
+
+  it('does not label a locked PR', async () => {
+    utils.setupJobsEnv('pr-labeler')
+
+    const context = new utils.MockContext(pullReqOpenedEvent)
+
+    const lockedPrs = structuredClone(listPullReqs)
+    lockedPrs[0].locked = true
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls`,
+        ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page')
+          return utils.mockResponse(200, page === '1' ? lockedPrs : [])({ request })
+        },
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/2/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, prListFiles),
+      ),
+    )
+
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    expect(observeReq.ref).toBeNull()
+  })
 })

--- a/__tests__/cronJobTest/labelPr.test.ts
+++ b/__tests__/cronJobTest/labelPr.test.ts
@@ -44,7 +44,7 @@ const server = setupServer(
 )
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/cronJobTest/lgtm.test.ts
+++ b/__tests__/cronJobTest/lgtm.test.ts
@@ -37,7 +37,7 @@ const server = setupServer(
 )
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/cronJobTest/lgtm.test.ts
+++ b/__tests__/cronJobTest/lgtm.test.ts
@@ -115,6 +115,34 @@ describe('cronLgtm', () => {
     })
   })
 
+  it('wont merge a locked PR even if the lgtm label is present', async () => {
+    utils.setupJobsEnv('lgtm')
+
+    const context = new utils.MockContext(pullReqOpenedEvent)
+
+    const lockedPrs = structuredClone(listPullReqs)
+    lockedPrs[0].locked = true
+    lockedPrs[0].labels[0].name = 'lgtm'
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls`,
+        ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page')
+          return utils.mockResponse(200, page === '1' ? lockedPrs : [])({ request })
+        },
+      ),
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    expect(observeReq.ref).toBeNull()
+  })
+
   it('wont merge the PR if the hold label is present', async () => {
     utils.setupJobsEnv('lgtm')
 

--- a/__tests__/cronJobTest/lgtm.test.ts
+++ b/__tests__/cronJobTest/lgtm.test.ts
@@ -140,7 +140,7 @@ describe('cronLgtm', () => {
     )
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
-    expect(observeReq.ref).toBeNull()
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
   })
 
   it('wont merge the PR if the hold label is present', async () => {
@@ -161,6 +161,15 @@ describe('cronLgtm', () => {
       default: true,
     })
 
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
     await expect(handleCronJobs(context)).resolves.not.toThrow()
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
   })
 })

--- a/__tests__/fixtures/pullReq/pullReqListPulls.json
+++ b/__tests__/fixtures/pullReq/pullReqListPulls.json
@@ -14,7 +14,7 @@
     "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
     "number": 2,
     "state": "open",
-    "locked": true,
+    "locked": false,
     "title": "Amazing new feature",
     "user": {
       "login": "octocat",

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -1,7 +1,8 @@
 import { Buffer } from 'node:buffer'
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -220,6 +221,49 @@ reviewers:
     expect(await observeReq.body()).toMatchObject({
       message: `Canceled through prow-github-actions by @some-user`,
     })
+  })
+
+  it('fails /approve cancel when the bot has no approved review', async () => {
+    const reviews = structuredClone(pullReqListReviews)
+    reviews[0].state = 'COMMENTED'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, reviews),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/approve cancel'
+    issueCommentEventAssign.comment.user.login = 'some-user'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('no latest review found to cancel'),
+    )
   })
 
   it('removes approval with the /approve cancel command if commenter is collaborator', async () => {

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -13,7 +13,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/assign.test.ts
+++ b/__tests__/issueCommentTest/assign.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import issueAssignedResp from '../fixtures/issues/assign/issueAssignedResponse.json'
@@ -237,6 +238,76 @@ describe('/assign', () => {
     expect(await observeReq.body()).toMatchObject({
       assignees: ['some-user'],
     })
+  })
+
+  it('fails when no requested user is authorized', async () => {
+    issueCommentEventAssign.comment.body = '/assign @some-user'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('no authorized users found'),
+    )
+  })
+
+  it('does not self assign when commenter is not authorized', async () => {
+    issueCommentEventAssign.comment.body = '/assign'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 
   it('assigns user if they have previously commented', async () => {

--- a/__tests__/issueCommentTest/assign.test.ts
+++ b/__tests__/issueCommentTest/assign.test.ts
@@ -12,7 +12,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/cc.test.ts
+++ b/__tests__/issueCommentTest/cc.test.ts
@@ -12,7 +12,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/cc.test.ts
+++ b/__tests__/issueCommentTest/cc.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
@@ -156,6 +157,7 @@ describe('/cc', () => {
     const commentContext = new utils.MockContext(issueCommentEvent)
 
     await handleIssueComment(commentContext)
+    await observeReq.called()
     expect(await observeReq.body()).toMatchObject({
       reviewers: ['some-user', 'other-user'],
     })
@@ -229,6 +231,68 @@ describe('/cc', () => {
     expect(await observeReq.body()).toMatchObject({
       reviewers: ['some-user'],
     })
+  })
+
+  it('fails when no requested user is authorized', async () => {
+    issueCommentEvent.comment.body = '/cc @some-user'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('no authorized users found'),
+    )
+  })
+
+  it('does not self cc when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/cc'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(201, pullReviewRequested, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 
   it('assigns user if they have previously commented', async () => {

--- a/__tests__/issueCommentTest/close.test.ts
+++ b/__tests__/issueCommentTest/close.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/close.test.ts
+++ b/__tests__/issueCommentTest/close.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -49,9 +50,29 @@ describe('/close', () => {
     })
   })
 
-  describe('error', () => {
-    it.skip('reply with error message cannot close', () => {
-      // TODO
-    })
+  it('does not close the issue when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/close'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/issueCommentTest/lock.test.ts
+++ b/__tests__/issueCommentTest/lock.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/lock.test.ts
+++ b/__tests__/issueCommentTest/lock.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -127,9 +128,57 @@ describe('/lock', () => {
     })
   })
 
-  describe('error', () => {
-    it.skip('reply with error message cannot lock', () => {
-      // TODO
-    })
+  it('locks the associated issue with given reason resolved', async () => {
+    issueCommentEvent.comment.body = '/lock resolved'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    // resolved is GitHub's default, so no lock_reason is sent
+    expect(await observeReq.ref?.text()).toBe('')
+  })
+
+  it('fails when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/lock'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('commenter is not a collaborator user'),
+    )
   })
 })

--- a/__tests__/issueCommentTest/meow.test.ts
+++ b/__tests__/issueCommentTest/meow.test.ts
@@ -14,10 +14,7 @@ const catApi = 'https://api.thecatapi.com/v1/images/search'
 
 const server = setupServer()
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
-afterEach(() => {
-  server.resetHandlers()
-  vi.restoreAllMocks()
-})
+afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 function contextFor(body: string) {

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -13,7 +13,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -82,9 +82,52 @@ describe('/milestone', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  describe('error', () => {
-    it.skip('reply with error message cannot milestone', () => {
-      // TODO
-    })
+  it('does not update the issue when the milestone does not exist', async () => {
+    issueCommentEvent.comment.body = '/milestone does not exist'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails when no milestone is provided', async () => {
+    issueCommentEvent.comment.body = '/milestone '
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('please provide a milestone to add'),
+    )
   })
 })

--- a/__tests__/issueCommentTest/reopen.test.ts
+++ b/__tests__/issueCommentTest/reopen.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/reopen.test.ts
+++ b/__tests__/issueCommentTest/reopen.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -49,9 +50,29 @@ describe('/reopen', () => {
     })
   })
 
-  describe('error', () => {
-    it.skip('reply with error message cannot open', () => {
-      // TODO
-    })
+  it('does not reopen the issue when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/reopen'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/issueCommentTest/retitle.test.ts
+++ b/__tests__/issueCommentTest/retitle.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/retitle.test.ts
+++ b/__tests__/issueCommentTest/retitle.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -49,9 +50,48 @@ describe('/retitle', () => {
     })
   })
 
-  describe('error', () => {
-    it.skip('reply with error message cannot retitle', () => {
-      // TODO
-    })
+  it('does not retitle when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/retitle much better title'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no new title is provided', async () => {
+    issueCommentEvent.comment.body = '/retitle'
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/issueCommentTest/unassign.test.ts
+++ b/__tests__/issueCommentTest/unassign.test.ts
@@ -12,7 +12,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/issueCommentTest/unassign.test.ts
+++ b/__tests__/issueCommentTest/unassign.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 
@@ -181,9 +182,37 @@ describe('/unassign', () => {
     })
   })
 
-  describe('error', () => {
-    it.skip('reply with error message if user not assigned', () => {
-      // TODO
-    })
+  it('does not unassign another user when commenter is not authorized', async () => {
+    issueCommentEventUnassign.comment.body = '/unassign @some-user'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueUnassignedResp, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEventUnassign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/issueCommentTest/uncc.test.ts
+++ b/__tests__/issueCommentTest/uncc.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import issueListComments from '../fixtures/issues/assign/issueListComments.json'
@@ -226,6 +227,66 @@ describe('/uncc', () => {
     expect(await observeReq.body()).toMatchObject({
       reviewers: ['some-user'],
     })
+  })
+
+  it('does not uncc another user when commenter is not authorized', async () => {
+    issueCommentEvent.comment.body = '/uncc @some-user'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('does not self uncc when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/uncc'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/requested_reviewers`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 
   it('uncc user if they have previously commented', async () => {

--- a/__tests__/issueCommentTest/uncc.test.ts
+++ b/__tests__/issueCommentTest/uncc.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -101,6 +101,30 @@ describe('area', () => {
     })
   })
 
+  it('fails when no area argument is in .prowlabels.yaml', async () => {
+    issueCommentEvent.comment.body = '/area not-a-real-label'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('area: command args missing from body'),
+    )
+  })
+
   it('fails the action when the label request fails', async () => {
     issueCommentEvent.comment.body = '/area important'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -12,11 +12,10 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())
-afterEach(() => vi.restoreAllMocks())
 afterAll(() => server.close())
 
 describe('area', () => {

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -12,13 +12,10 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
-afterEach(() => {
-  server.resetHandlers()
-  vi.restoreAllMocks()
-})
+afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('hold', () => {

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -46,7 +46,8 @@ describe('hold', () => {
     issueCommentEvent.comment.body = '/hold cancel'
     const commentContext = new utils.MockContext(issueCommentEvent)
 
-    issuePayload.labels.push({
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
       id: 1,
       node_id: '123',
       url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
@@ -65,13 +66,35 @@ describe('hold', () => {
       ),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-        utils.mockResponse(200, issuePayload, observeReqGet),
+        utils.mockResponse(200, payload, observeReqGet),
       ),
     )
 
     await handleIssueComment(commentContext)
     await expect(observeReqDelete.called()).resolves.toBe('called')
     await expect(observeReqGet.called()).resolves.toBe('called')
+  })
+
+  it('does not issue a removal with /hold cancel when hold is absent', async () => {
+    issueCommentEvent.comment.body = '/hold cancel'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReqDelete = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReqDelete.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 
   it('fails the action when the hold removal fails', async () => {

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
@@ -98,5 +99,29 @@ describe('kind', () => {
     expect(await observeReq.body()).toMatchObject({
       labels: ['kind/cleanup', 'kind/failing-test'],
     })
+  })
+
+  it('fails when no kind argument is in .prowlabels.yaml', async () => {
+    issueCommentEvent.comment.body = '/kind not-a-real-label'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('kind: command args missing from body'),
+    )
   })
 })

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -16,11 +16,10 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())
-afterEach(() => vi.restoreAllMocks())
 afterAll(() => server.close())
 
 describe('lgtm', () => {

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -65,7 +65,8 @@ describe('lgtm', () => {
     issueCommentEvent.comment.body = '/lgtm cancel'
     const commentContext = new utils.MockContext(issueCommentEvent)
 
-    issuePayload.labels.push({
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
       id: 1,
       node_id: '123',
       url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
@@ -75,10 +76,43 @@ describe('lgtm', () => {
       default: true,
     })
 
+    const observeReq = new utils.ObserveRequest()
     server.use(
       http.delete(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
-        utils.mockResponse(200),
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    await handleIssueComment(commentContext)
+    await expect(observeReq.called()).resolves.toBe('called')
+  })
+
+  it('does not issue a removal with /lgtm cancel when lgtm is absent', async () => {
+    issueCommentEvent.comment.body = '/lgtm cancel'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeReq),
       ),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
@@ -98,7 +132,10 @@ describe('lgtm', () => {
       ),
     )
 
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
     await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 
   it('adds label if commenter is collaborator', async () => {

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
@@ -98,5 +99,29 @@ describe('priority', () => {
     expect(await observeReq.body()).toMatchObject({
       labels: ['priority/low', 'priority/high'],
     })
+  })
+
+  it('fails when no priority argument is in .prowlabels.yaml', async () => {
+    issueCommentEvent.comment.body = '/priority not-a-real-label'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('priority: command args missing from body'),
+    )
   })
 })

--- a/__tests__/label/remove.test.ts
+++ b/__tests__/label/remove.test.ts
@@ -12,13 +12,10 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
-afterEach(() => {
-  server.resetHandlers()
-  vi.restoreAllMocks()
-})
+afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('remove', () => {

--- a/__tests__/label/remove.test.ts
+++ b/__tests__/label/remove.test.ts
@@ -95,6 +95,34 @@ describe('remove', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  it('fails when none of the requested labels are on the issue', async () => {
+    issueCommentEvent.comment.body = '/remove not-present'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/not-present`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('command args missing from body'),
+    )
+  })
+
   it('fails the action when a label removal fails', async () => {
     issueCommentEvent.comment.body = '/remove some-label'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/pullReqTest/onPrLgtm.test.ts
+++ b/__tests__/pullReqTest/onPrLgtm.test.ts
@@ -11,7 +11,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/__tests__/pullReqTest/onPrLgtm.test.ts
+++ b/__tests__/pullReqTest/onPrLgtm.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handlePullReq } from '../../src/pullReq/handlePullReq'
 import issuePayload from '../fixtures/issues/issue.json'
@@ -25,7 +26,8 @@ describe('onPrLgtm', () => {
   it('removes the label lgtm', async () => {
     const prContext = new utils.MockContext(pullReqEvent)
 
-    issuePayload.labels.push({
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
       id: 1999,
       node_id: 'MEOW111=',
       url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
@@ -35,6 +37,26 @@ describe('onPrLgtm', () => {
       default: false,
     })
 
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    await expect(handlePullReq(prContext)).resolves.not.toThrow()
+    await expect(observeReq.called()).resolves.toBe('called')
+  })
+
+  it('does not issue a removal when lgtm is absent', async () => {
+    const prContext = new utils.MockContext(pullReqEvent)
+
+    const observeReq = new utils.ObserveRequest()
     server.use(
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
@@ -42,10 +64,13 @@ describe('onPrLgtm', () => {
       ),
       http.delete(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
-        utils.mockResponse(200),
+        utils.mockResponse(200, null, observeReq),
       ),
     )
 
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
     await expect(handlePullReq(prContext)).resolves.not.toThrow()
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -3,7 +3,9 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { handleCronJobs } from '../src/cronJobs/handleCronJob'
 import { handleIssueComment } from '../src/issueComment/handleIssueComment'
+import { handlePullReq } from '../src/pullReq/handlePullReq'
 import { run } from '../src/run'
 
 vi.mock('../src/issueComment/handleIssueComment', () => ({
@@ -19,6 +21,8 @@ vi.mock('../src/cronJobs/handleCronJob', () => ({
 const mockedHandle = handleIssueComment as MockedFunction<
   typeof handleIssueComment
 >
+const mockedHandlePullReq = handlePullReq as MockedFunction<typeof handlePullReq>
+const mockedHandleCronJobs = handleCronJobs as MockedFunction<typeof handleCronJobs>
 
 describe('run', () => {
   beforeEach(() => {
@@ -46,6 +50,52 @@ describe('run', () => {
     releaseHandler()
     await running
     expect(resolved).toBe(true)
+  })
+
+  it('dispatches issue_comment to handleIssueComment', async () => {
+    mockedHandle.mockResolvedValue()
+
+    await run()
+
+    expect(mockedHandle).toHaveBeenCalledTimes(1)
+    expect(mockedHandlePullReq).not.toHaveBeenCalled()
+    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('dispatches pull_request to handlePullReq', async () => {
+    github.context.eventName = 'pull_request'
+    mockedHandlePullReq.mockResolvedValue()
+
+    await run()
+
+    expect(mockedHandlePullReq).toHaveBeenCalledTimes(1)
+    expect(mockedHandle).not.toHaveBeenCalled()
+    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
+  })
+
+  it('dispatches schedule to handleCronJobs', async () => {
+    github.context.eventName = 'schedule'
+    mockedHandleCronJobs.mockResolvedValue()
+
+    await run()
+
+    expect(mockedHandleCronJobs).toHaveBeenCalledTimes(1)
+    expect(mockedHandle).not.toHaveBeenCalled()
+    expect(mockedHandlePullReq).not.toHaveBeenCalled()
+  })
+
+  it('logs an error for an unsupported event without failing', async () => {
+    github.context.eventName = 'push'
+    const logError = vi.spyOn(core, 'error').mockImplementation(() => {})
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await expect(run()).resolves.toBeUndefined()
+
+    expect(logError).toHaveBeenCalledWith('push not yet supported')
+    expect(setFailed).not.toHaveBeenCalled()
+    expect(mockedHandle).not.toHaveBeenCalled()
+    expect(mockedHandlePullReq).not.toHaveBeenCalled()
+    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
   })
 
   it('reports a dispatched handler rejection through setFailed', async () => {

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -1,7 +1,7 @@
 import type { MockedFunction } from 'vitest'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../src/issueComment/handleIssueComment'
 import { run } from '../src/run'
@@ -25,8 +25,6 @@ describe('run', () => {
     vi.resetAllMocks()
     github.context.eventName = 'issue_comment'
   })
-
-  afterEach(() => vi.restoreAllMocks())
 
   it('does not resolve until the dispatched handler settles', async () => {
     let releaseHandler!: () => void

--- a/__tests__/testUtils.ts
+++ b/__tests__/testUtils.ts
@@ -12,16 +12,19 @@ export const MockContext = class extends Context {
   }
 }
 
-function clearInputEnv() {
+// Drop action inputs and the runner-provided GITHUB_* variables so that tests
+// are hermetic when they run inside GitHub Actions (github.context reads
+// GITHUB_REPOSITORY, GITHUB_EVENT_PATH, GITHUB_API_URL, ... from the env).
+function clearActionEnv() {
   for (const key of Object.keys(process.env)) {
-    if (key.startsWith('INPUT_')) {
+    if (key.startsWith('INPUT_') || key.startsWith('GITHUB_')) {
       delete process.env[key]
     }
   }
 }
 
 export function setupActionsEnv(command: string = '') {
-  clearInputEnv()
+  clearActionEnv()
 
   // set the neccessary env variables expected by the action:
   // https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith
@@ -30,7 +33,7 @@ export function setupActionsEnv(command: string = '') {
 }
 
 export function setupJobsEnv(arg: string = '') {
-  clearInputEnv()
+  clearActionEnv()
 
   // set the neccessary env variables expected by the action:
   // https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith

--- a/__tests__/testUtils.ts
+++ b/__tests__/testUtils.ts
@@ -7,12 +7,21 @@ export const api = 'https://api.github.com'
 export const MockContext = class extends Context {
   constructor(payload: WebhookPayload) {
     super()
-    this.payload = payload
+    // clone so tests never mutate the shared imported fixture
+    this.payload = structuredClone(payload)
+  }
+}
+
+function clearInputEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('INPUT_')) {
+      delete process.env[key]
+    }
   }
 }
 
 export function setupActionsEnv(command: string = '') {
-  process.env = {}
+  clearInputEnv()
 
   // set the neccessary env variables expected by the action:
   // https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith
@@ -21,7 +30,7 @@ export function setupActionsEnv(command: string = '') {
 }
 
 export function setupJobsEnv(arg: string = '') {
-  process.env = {}
+  clearInputEnv()
 
   // set the neccessary env variables expected by the action:
   // https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith
@@ -58,14 +67,35 @@ export class ObserveRequest {
     }
   }
 
-  public called() {
-    return new Promise<string>((resolve) => {
+  // resolves once the observed request arrives; rejects after timeoutMs so a
+  // missing request fails the test instead of hanging the worker
+  public called(timeoutMs = 2000) {
+    return new Promise<string>((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs
       const interval = setInterval(() => {
         if (this._ref) {
-          resolve('called')
           clearInterval(interval)
+          resolve('called')
+        }
+        else if (Date.now() >= deadline) {
+          clearInterval(interval)
+          reject(new Error(`observed request was not called within ${timeoutMs}ms`))
         }
       }, 1)
+    })
+  }
+
+  // resolves after waitMs if the request never arrived; rejects if it did
+  public notCalled(waitMs = 50) {
+    return new Promise<string>((resolve, reject) => {
+      setTimeout(() => {
+        if (this._ref) {
+          reject(new Error(`expected request not to be called: ${this._ref.method} ${this._ref.url}`))
+        }
+        else {
+          resolve('not called')
+        }
+      }, waitMs)
     })
   }
 }

--- a/__tests__/utils/auth.test.ts
+++ b/__tests__/utils/auth.test.ts
@@ -19,11 +19,12 @@ import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 import * as utils from '../testUtils'
 
 const server = setupServer()
-beforeAll(() =>
+beforeAll(() => {
+  utils.setupActionsEnv()
   server.listen({
     onUnhandledRequest: 'error',
-  }),
-)
+  })
+})
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 

--- a/__tests__/utils/auth.test.ts
+++ b/__tests__/utils/auth.test.ts
@@ -1,0 +1,277 @@
+import { Buffer } from 'node:buffer'
+
+import { Octokit } from '@octokit/rest'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  assertAuthorizedByOwnersOrMembership,
+  checkCollaborator,
+  checkCommenterAuth,
+  checkIssueComments,
+  checkOrgMember,
+  getOrgCollabCommentUsers,
+} from '../../src/utils/auth'
+import issueListComments from '../fixtures/issues/assign/issueListComments.json'
+import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+
+import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const octokit = new Octokit({ auth: 'some-token' })
+const context = new utils.MockContext(issueCommentEvent)
+
+function ownersResponse(owners: string) {
+  return {
+    type: 'file',
+    encoding: 'base64',
+    size: 4096,
+    name: 'OWNERS',
+    path: 'OWNERS',
+    content: Buffer.from(owners).toString('base64'),
+  }
+}
+
+describe('checkOrgMember', () => {
+  it('is true when the org membership check returns 204', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    await expect(checkOrgMember(octokit, context, 'some-user')).resolves.toBe(true)
+  })
+
+  it.each([404, 500])('is false when the org membership check returns %i', async (status) => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(status),
+      ),
+    )
+
+    await expect(checkOrgMember(octokit, context, 'some-user')).resolves.toBe(false)
+  })
+
+  it('is false when the payload has no repository', async () => {
+    const noRepo = new utils.MockContext({})
+
+    await expect(checkOrgMember(octokit, noRepo, 'some-user')).resolves.toBe(false)
+  })
+})
+
+describe('checkCollaborator', () => {
+  it('is true when the collaborator check returns 204', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    await expect(checkCollaborator(octokit, context, 'some-user')).resolves.toBe(true)
+  })
+
+  it.each([404, 500])('is false when the collaborator check returns %i', async (status) => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(status),
+      ),
+    )
+
+    await expect(checkCollaborator(octokit, context, 'some-user')).resolves.toBe(false)
+  })
+})
+
+describe('checkIssueComments', () => {
+  it('is true when the user has commented on the issue', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments),
+      ),
+    )
+
+    await expect(checkIssueComments(octokit, context, 1, 'some-user')).resolves.toBe(true)
+  })
+
+  it('is false when the user has not commented on the issue', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments),
+      ),
+    )
+
+    await expect(checkIssueComments(octokit, context, 1, 'nobody')).resolves.toBe(false)
+  })
+
+  it('is false when listing comments fails', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(500),
+      ),
+    )
+
+    await expect(checkIssueComments(octokit, context, 1, 'some-user')).resolves.toBe(false)
+  })
+})
+
+describe('checkCommenterAuth', () => {
+  it('is false when the user fails every check', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    await expect(checkCommenterAuth(octokit, context, 1, 'some-user')).resolves.toBe(false)
+  })
+
+  it('is true when the user has only commented previously', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, issueListComments),
+      ),
+    )
+
+    await expect(checkCommenterAuth(octokit, context, 1, 'some-user')).resolves.toBe(true)
+  })
+})
+
+describe('getOrgCollabCommentUsers', () => {
+  it('keeps only the users that pass a check', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/nobody`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/nobody`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    await expect(
+      getOrgCollabCommentUsers(octokit, context, 1, ['some-user', 'nobody']),
+    ).resolves.toEqual(['some-user'])
+  })
+})
+
+describe('assertAuthorizedByOwnersOrMembership', () => {
+  it('throws when fetching the OWNERS file fails with a non-404', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(500),
+      ),
+    )
+
+    await expect(
+      assertAuthorizedByOwnersOrMembership(octokit, context, 'approvers', 'Codertocat'),
+    ).rejects.toThrow('error checking for an OWNERS file at the root of the repository')
+  })
+
+  it('throws when the OWNERS response has no content or encoding', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, { type: 'file', name: 'OWNERS', path: 'OWNERS' }),
+      ),
+    )
+
+    await expect(
+      assertAuthorizedByOwnersOrMembership(octokit, context, 'approvers', 'Codertocat'),
+    ).rejects.toThrow('invalid OWNERS file returned from GitHub API')
+  })
+
+  it('throws when the OWNERS file has no entry for the role', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, ownersResponse('reviewers:\n- Codertocat\n')),
+      ),
+    )
+
+    await expect(
+      assertAuthorizedByOwnersOrMembership(octokit, context, 'approvers', 'Codertocat'),
+    ).rejects.toThrow('Codertocat is not included in the approvers role in the OWNERS file')
+  })
+
+  it('resolves when the user holds the role in the OWNERS file', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, ownersResponse('approvers:\n- Codertocat\n')),
+      ),
+    )
+
+    await expect(
+      assertAuthorizedByOwnersOrMembership(octokit, context, 'approvers', 'Codertocat'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('falls back to membership when there is no OWNERS file', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    await expect(
+      assertAuthorizedByOwnersOrMembership(octokit, context, 'approvers', 'Codertocat'),
+    ).rejects.toThrow('Codertocat is not a org member or collaborator')
+  })
+})

--- a/__tests__/utils/labeling.test.ts
+++ b/__tests__/utils/labeling.test.ts
@@ -14,7 +14,7 @@ import * as utils from '../testUtils'
 const server = setupServer()
 beforeAll(() =>
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: 'error',
   }),
 )
 afterEach(() => server.resetHandlers())

--- a/dist/index.js
+++ b/dist/index.js
@@ -2161,7 +2161,7 @@ async function kind(context = github.context) {
     commentArgs = (0, labeling_1.addPrefix)('kind', commentArgs);
     // no arguments after command provided
     if (commentArgs.length === 0) {
-        throw new Error(`area: command args missing from body`);
+        throw new Error(`kind: command args missing from body`);
     }
     await (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
 }
@@ -2342,7 +2342,7 @@ async function priority(context = github.context) {
     commentArgs = (0, labeling_1.addPrefix)('priority', commentArgs);
     // no arguments after command provided
     if (commentArgs.length === 0) {
-        throw new Error(`area: command args missing from body`);
+        throw new Error(`priority: command args missing from body`);
     }
     await (0, labeling_1.labelIssue)(octokit, context, issueNumber, commentArgs);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -162,7 +162,7 @@ async function cronLgtm(currentPage, context) {
         if (pr.state === 'closed') {
             return;
         }
-        if (pr.state === 'locked') {
+        if (pr.locked) {
             return;
         }
         try {
@@ -331,7 +331,7 @@ async function cronLabelPr(currentPage, context) {
         if (pr.state === 'closed') {
             return;
         }
-        if (pr.state === 'locked') {
+        if (pr.locked) {
             return;
         }
         await labelPr(pr.number, context, octokit);

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -54,7 +54,7 @@ export async function cronLgtm(
         return
       }
 
-      if (pr.state === 'locked') {
+      if (pr.locked) {
         return
       }
 

--- a/src/cronJobs/prLabeler.ts
+++ b/src/cronJobs/prLabeler.ts
@@ -64,7 +64,7 @@ export async function cronLabelPr(
         return
       }
 
-      if (pr.state === 'locked') {
+      if (pr.locked) {
         return
       }
 

--- a/src/labels/kind.ts
+++ b/src/labels/kind.ts
@@ -46,7 +46,7 @@ export async function kind(context: Context = github.context): Promise<void> {
 
   // no arguments after command provided
   if (commentArgs.length === 0) {
-    throw new Error(`area: command args missing from body`)
+    throw new Error(`kind: command args missing from body`)
   }
 
   await labelIssue(octokit, context, issueNumber, commentArgs)

--- a/src/labels/priority.ts
+++ b/src/labels/priority.ts
@@ -46,7 +46,7 @@ export async function priority(context: Context = github.context): Promise<void>
 
   // no arguments after command provided
   if (commentArgs.length === 0) {
-    throw new Error(`area: command args missing from body`)
+    throw new Error(`priority: command args missing from body`)
   }
 
   await labelIssue(octokit, context, issueNumber, commentArgs)

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -5,12 +5,12 @@ export default defineConfig({
     environment: 'node',
     include: ['__tests__/**/*.test.ts'],
     globals: false,
-    // Mirrors Jest's `clearMocks: true` + `resetMocks: true`. Note: Vitest's
-    // mockReset restores a spy's original implementation (Jest 29 reset it to
-    // return undefined); the suite passes identically under both semantics.
+    // Mirrors Jest's `clearMocks: true` + `resetMocks: true` + `restoreMocks: true`.
+    // Note: Vitest's mockReset restores a spy's original implementation (Jest 29
+    // reset it to return undefined); the suite passes identically under both semantics.
     clearMocks: true,
     mockReset: true,
-    restoreMocks: false,
+    restoreMocks: true,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -15,6 +15,12 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       reporter: ['text', 'text-summary'],
+      thresholds: {
+        lines: 85,
+        branches: 83,
+        functions: 91,
+        statements: 85,
+      },
     },
   },
 })


### PR DESCRIPTION
# Description

Follow-up to the testing assessment. Repairs trust in the unit suite: one real bug fixed, four assertion-free tests made real, infrastructure hardened so un-mocked API calls fail loudly, negative/edge paths covered, and coverage thresholds gate CI.

**Tests: 120 passed / 6 skipped → 169 passed / 0 skipped** (26 → 28 files). Coverage: 88.0% statements / 88.3% branches / 96.6% functions.

## Bug fix — `fix(cron): skip locked pull requests`
`src/cronJobs/lgtm.ts` and `prLabeler.ts` checked `pr.state === 'locked'`, but GitHub's PR `state` is only `open|closed` — `locked` is a separate boolean. Locked PRs were never skipped; the `lgtm` cron job would merge them. The test fixture even had `locked: true` and the merge test still merged it. Fixed to `if (pr.locked)`, with a failing-test-first regression test for both cron jobs. Fixture corrected to `locked: false` so happy paths still exercise the merge.

## Test infrastructure — `test: harden test utilities and fail on unhandled requests`
- `MockContext` deep-clones payloads (`structuredClone`) — tests no longer mutate shared fixtures.
- `ObserveRequest.called()` rejects after a timeout instead of polling a `setInterval` forever (the likely cause of the old "worker failed to exit gracefully" warning); new `notCalled()` for "must not be called" assertions.
- All 21 msw servers switched from `onUnhandledRequest: 'warn'` to `'error'`. No test needed new handlers — everything was already mocked — but stray requests now fail instead of being silently swallowed.
- `restoreMocks: true` globally; per-file `afterEach(vi.restoreAllMocks)` removed.
- `setupActionsEnv` no longer nukes `process.env` wholesale (only `INPUT_*`).

## Real assertions — `test: assert merge-safety and label-removal behaviour`
- cron `lgtm` with `hold` label: asserts the merge PUT is **never called** (previously only `resolves.not.toThrow()`).
- `/lgtm cancel`: asserts the DELETE fires (previously zero `expect` calls); plus no-op when label absent.
- `onPrLgtm` and `/hold cancel`: DELETE fires when present / not when absent.

## Negative & error paths — `test: cover negative authorization and error paths`
Non-collaborator `/close` `/reopen` `/retitle` `/lock` (`lock` throws — asserted); non-member `/unassign` `/uncc`; `/assign` `/cc` with no authorized target; `/approve cancel` with no bot review; `/milestone` not found / empty; `/area` `/kind` `/priority` `/remove` with no valid args; `run.ts` dispatch for all three events + unknown; `handleCronJobs` unknown/empty job; new `__tests__/utils/auth.test.ts` (16 direct tests for org/collaborator/OWNERS paths). Fixed copy-paste `area:` in `kind.ts`/`priority.ts` error messages. Deleted the 6 `it.skip // TODO` placeholders (they described behaviour that doesn't exist).

## Coverage gate — `test: enforce coverage thresholds in CI`
`vitest.config.mjs` thresholds: lines 85 / branches 83 / functions 91 / statements 85 (≈ actual − 5). `test.yml` runs `npm run test:coverage`. Verified the gate fails CI when unmet.

# Testing
- [x] `npm run all` passes; `dist/` regenerated for the two `src/` changes and stable across repeated packs
- [x] Failing-test-first evidence for the locked bug in commit `fix(cron): skip locked pull requests`
- [x] `npm audit` 0 vulnerabilities; lockfile untouched
