### PR TITLE
feat: Prow-style aliases for lgtm/approve/hold, /milestone clear, and line-anchored command matching

### DIFF
--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -140,6 +140,25 @@ describe('dist/index.js', () => {
     ])
   })
 
+  it('issue_comment /unhold removes the hold label when /hold is configured', async () => {
+    gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'hold' }] } })
+    gh.route('DELETE', `${repo}/issues/1/labels/hold`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/unhold'),
+      inputs: { ...token, 'prow-commands': '/hold' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      `GET ${repo}/issues/1`,
+      `DELETE ${repo}/issues/1/labels/hold`,
+    ])
+  })
+
   it('pull_request lgtm job removes the lgtm label on a new push', async () => {
     gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'lgtm' }] } })
     gh.route('DELETE', `${repo}/issues/1/labels/lgtm`, { status: 200, body: [] })

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -266,6 +266,128 @@ reviewers:
     )
   })
 
+  it('removes approval with /remove-approve if commenter is collaborator', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews),
+      ),
+    )
+
+    const observeDismiss = new utils.ObserveRequest()
+    const observeCreate = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeDismiss),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeCreate),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/remove-approve'
+    issueCommentEventAssign.comment.user.login = 'some-user'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeDismiss.called()
+    expect(await observeDismiss.body()).toMatchObject({
+      message: `Canceled through prow-github-actions by @some-user`,
+    })
+    await expect(observeCreate.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails /remove-approve for a commenter who is not an approver', async () => {
+    const wantErr = `Codertocat is not a org member or collaborator`
+
+    const observeComment = new utils.ObserveRequest()
+    const observeDismiss = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeComment),
+      ),
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeDismiss),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/remove-approve'
+    issueCommentEventAssign.comment.user.login = 'Codertocat'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeComment.called()
+    expect(await observeComment.body().then(body => body.body)).toContain(wantErr)
+    await expect(observeDismiss.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining(wantErr))
+  })
+
+  it('approves with /approve no-issue if commenter is an org member', async () => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/approve no-issue'
+    issueCommentEventAssign.comment.user.login = 'Codertocat'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toMatchObject({
+      event: 'APPROVE',
+    })
+  })
+
   it('removes approval with the /approve cancel command if commenter is collaborator', async () => {
     server.use(
       http.get(

--- a/__tests__/issueCommentTest/handleIssueComment.test.ts
+++ b/__tests__/issueCommentTest/handleIssueComment.test.ts
@@ -1,11 +1,13 @@
 import * as core from '@actions/core'
 import { expect, it, vi } from 'vitest'
 
+import * as approve from '../../src/issueComment/approve'
 import * as assign from '../../src/issueComment/assign'
 import * as cc from '../../src/issueComment/cc'
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as unassign from '../../src/issueComment/unassign'
 import * as hold from '../../src/labels/hold'
+import * as lgtm from '../../src/labels/lgtm'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 import * as utils from '../testUtils'
@@ -154,4 +156,82 @@ it('fails for an unsupported command in prow-commands', async () => {
   expect(setFailed).toHaveBeenCalledWith(
     expect.stringContaining('could not execute /not-a-command'),
   )
+})
+
+it('dispatches /remove-lgtm once to lgtm when /lgtm is configured', async () => {
+  utils.setupActionsEnv('/lgtm')
+
+  vi.spyOn(lgtm, 'lgtm').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/remove-lgtm'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(lgtm.lgtm).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it.each(['/unhold', '/remove-hold'])('dispatches %s once to hold when /hold is configured', async (body) => {
+  utils.setupActionsEnv('/hold')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+
+  issueCommentEvent.comment.body = body
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).toHaveBeenCalledTimes(1)
+})
+
+it('dispatches /remove-approve once to approve when /approve is configured', async () => {
+  utils.setupActionsEnv('/approve')
+
+  vi.spyOn(approve, 'approve').mockImplementation(() => Promise.resolve())
+
+  issueCommentEvent.comment.body = '/remove-approve'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(approve.approve).toHaveBeenCalledTimes(1)
+})
+
+it('accepts an alias in prow-commands and resolves it to the base command', async () => {
+  utils.setupActionsEnv('/unhold')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/unhold'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('runs a command once when both it and an alias are configured', async () => {
+  utils.setupActionsEnv('/hold /unhold /remove-hold')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+
+  issueCommentEvent.comment.body = '/hold'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).toHaveBeenCalledTimes(1)
+})
+
+it('does not dispatch an alias whose base command is not configured', async () => {
+  utils.setupActionsEnv('/assign')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+  vi.spyOn(assign, 'assign').mockImplementation(() => Promise.resolve())
+
+  issueCommentEvent.comment.body = '/unhold'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).not.toHaveBeenCalled()
+  expect(assign.assign).not.toHaveBeenCalled()
 })

--- a/__tests__/issueCommentTest/handleIssueComment.test.ts
+++ b/__tests__/issueCommentTest/handleIssueComment.test.ts
@@ -1,9 +1,11 @@
+import * as core from '@actions/core'
 import { expect, it, vi } from 'vitest'
 
 import * as assign from '../../src/issueComment/assign'
 import * as cc from '../../src/issueComment/cc'
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
 import * as unassign from '../../src/issueComment/unassign'
+import * as hold from '../../src/labels/hold'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
 import * as utils from '../testUtils'
@@ -82,4 +84,74 @@ it('handles commands on both newlines and spaces', async () => {
   expect(assign.assign).toHaveBeenCalledTimes(1)
   expect(unassign.unassign).toHaveBeenCalledTimes(1)
   expect(cc.cc).toHaveBeenCalledTimes(1)
+})
+
+it('ignores a command mentioned mid-sentence', async () => {
+  utils.setupActionsEnv('/hold')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = 'please do not /hold this yet'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).not.toHaveBeenCalled()
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('dispatches a command preceded by whitespace', async () => {
+  utils.setupActionsEnv('/hold')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+
+  issueCommentEvent.comment.body = 'some context\n   /hold'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).toHaveBeenCalledTimes(1)
+})
+
+it('tolerates extra whitespace in the prow-commands config', async () => {
+  utils.setupActionsEnv('  /assign  \n\n/unassign ')
+
+  vi.spyOn(assign, 'assign').mockImplementation(() => Promise.resolve())
+  vi.spyOn(unassign, 'unassign').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/assign\n/unassign'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(assign.assign).toHaveBeenCalledTimes(1)
+  expect(unassign.unassign).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('fails when prow-commands is empty', async () => {
+  utils.setupActionsEnv('')
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/assign'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(setFailed).toHaveBeenCalledWith(
+    expect.stringContaining('please provide a list of space delimited commands'),
+  )
+})
+
+it('fails for an unsupported command in prow-commands', async () => {
+  utils.setupActionsEnv('/not-a-command')
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/not-a-command'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(setFailed).toHaveBeenCalledWith(
+    expect.stringContaining('could not execute /not-a-command'),
+  )
 })

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -82,7 +82,7 @@ describe('/milestone', () => {
     expect(spy).toHaveBeenCalled()
   })
 
-  it('does not update the issue when the milestone does not exist', async () => {
+  it('fails and lists the available milestones when the milestone does not exist', async () => {
     issueCommentEvent.comment.body = '/milestone does not exist'
 
     server.use(
@@ -109,7 +109,89 @@ describe('/milestone', () => {
     const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
     await handleIssueComment(commentContext)
     await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('milestone "does not exist" not found. Available milestones: some milestone'),
+    )
+  })
+
+  it('reports none when the repository has no milestones', async () => {
+    issueCommentEvent.comment.body = '/milestone v9'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, []),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('milestone "v9" not found. Available milestones: none'),
+    )
+  })
+
+  it('clears the milestone with /milestone clear', async () => {
+    issueCommentEvent.comment.body = '/milestone clear'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      milestone: null,
+    })
     expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('does not clear the milestone when commenter is not a collaborator', async () => {
+    issueCommentEvent.comment.body = '/milestone clear'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('not authorized to set a milestone'),
+    )
   })
 
   it('fails when no milestone is provided', async () => {

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -113,7 +113,7 @@ describe('/milestone', () => {
   })
 
   it('fails when no milestone is provided', async () => {
-    issueCommentEvent.comment.body = '/milestone '
+    issueCommentEvent.comment.body = '/milestone'
 
     server.use(
       http.get(

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -97,6 +97,101 @@ describe('hold', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it.each(['/unhold', '/remove-hold'])('removes the hold label with %s', async (body) => {
+    issueCommentEvent.comment.body = body
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
+      id: 2,
+      node_id: '456',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/hold',
+      name: 'hold',
+      description: '',
+      color: 'f29513',
+      default: true,
+    })
+
+    const observeReqDelete = new utils.ObserveRequest()
+    const observeReqAdd = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReqAdd),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReqDelete.called()).resolves.toBe('called')
+    await expect(observeReqAdd.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it.each(['/unhold', '/remove-hold'])('does not issue a removal with %s when hold is absent', async (body) => {
+    issueCommentEvent.comment.body = body
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReqDelete = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issuePayload),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReqDelete.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('removes the hold label when /unhold is the configured command', async () => {
+    utils.setupActionsEnv('/unhold')
+    issueCommentEvent.comment.body = '/unhold'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
+      id: 2,
+      node_id: '456',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/hold',
+      name: 'hold',
+      description: '',
+      color: 'f29513',
+      default: true,
+    })
+
+    const observeReqDelete = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReqDelete.called()).resolves.toBe('called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('fails the action when the hold removal fails', async () => {
     issueCommentEvent.comment.body = '/hold cancel'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -104,6 +104,96 @@ describe('lgtm', () => {
     await expect(observeReq.called()).resolves.toBe('called')
   })
 
+  it('removes the lgtm label with /remove-lgtm', async () => {
+    issueCommentEvent.comment.body = '/remove-lgtm'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({
+      id: 1,
+      node_id: '123',
+      url: 'https://api.github.com/repos/octocat/Hello-World/labels/lgtm',
+      name: 'lgtm',
+      description: 'looks good to me',
+      color: 'f29513',
+      default: true,
+    })
+
+    const observeDelete = new utils.ObserveRequest()
+    const observeAdd = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeAdd),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDelete.called()).resolves.toBe('called')
+    await expect(observeAdd.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('does not remove the lgtm label with /remove-lgtm from an unauthorized user', async () => {
+    issueCommentEvent.comment.body = '/remove-lgtm'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const wantErr = `Codertocat is not a org member or collaborator`
+
+    const observeDelete = new utils.ObserveRequest()
+    const observeComment = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeComment),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeComment.called()
+    expect(await observeComment.body().then(body => body.body)).toContain(wantErr)
+    await expect(observeDelete.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining(wantErr))
+  })
+
   it('does not issue a removal with /lgtm cancel when lgtm is absent', async () => {
     issueCommentEvent.comment.body = '/lgtm cancel'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getCommandArgs, getLineArgs } from '../../src/utils/command'
+import { getCommandArgs, getLineArgs, hasCommand } from '../../src/utils/command'
 
 it('handles comments with multiple lines', () => {
   const body = `Here is something
@@ -38,5 +38,78 @@ describe('strips at signs', () => {
     const output = getCommandArgs('/command', body)
 
     expect(output).toMatchObject(['user@name', 'other@username'])
+  })
+})
+
+describe('hasCommand', () => {
+  it('matches a command at the start of a line', () => {
+    expect(hasCommand('/lgtm', '/lgtm')).toBe(true)
+    expect(hasCommand('/lgtm', 'looks fine\n/lgtm cancel')).toBe(true)
+    expect(hasCommand('/lgtm', '  /lgtm')).toBe(true)
+    expect(hasCommand('/lgtm', '\t/lgtm')).toBe(true)
+    expect(hasCommand('/lgtm', '/kind bug\r\n/lgtm\r\n')).toBe(true)
+  })
+
+  it('does not match a longer command sharing the prefix', () => {
+    expect(hasCommand('/lgtm', '/remove-lgtm')).toBe(false)
+    expect(hasCommand('/hold', '/remove-hold')).toBe(false)
+    expect(hasCommand('/hold', '/holdon')).toBe(false)
+    expect(hasCommand('/assign', '/unassign')).toBe(false)
+  })
+
+  it('does not match a mention mid-sentence', () => {
+    expect(hasCommand('/hold', 'please do not /hold this')).toBe(false)
+    expect(hasCommand('/lgtm', 'the /lgtm command adds a label')).toBe(false)
+  })
+
+  it('treats regex metacharacters in the command literally', () => {
+    expect(hasCommand('/a.b', '/a.b')).toBe(true)
+    expect(hasCommand('/a.b', '/axb')).toBe(false)
+  })
+})
+
+describe('anchored argument parsing', () => {
+  it('throws when only a longer command sharing the prefix is present', () => {
+    expect(() => getCommandArgs('/lgtm', '/remove-lgtm')).toThrow(
+      'command /lgtm missing from body',
+    )
+  })
+
+  it('throws when the command is only mentioned mid-sentence', () => {
+    expect(() => getCommandArgs('/hold', 'please /hold this')).toThrow(
+      'command /hold missing from body',
+    )
+  })
+
+  it('accepts leading whitespace before the command', () => {
+    expect(getCommandArgs('/lgtm', '   /lgtm cancel')).toMatchObject(['cancel'])
+    expect(getLineArgs('/milestone', '  /milestone v1.2')).toBe('v1.2')
+  })
+
+  it('uses the last matching line', () => {
+    const body = '/lgtm cancel\nchanged my mind\n/lgtm'
+
+    expect(getCommandArgs('/lgtm', body)).toMatchObject([])
+  })
+
+  it('returns no arguments for a bare command', () => {
+    expect(getCommandArgs('/lgtm', '/lgtm')).toMatchObject([])
+  })
+})
+
+describe('getLineArgs', () => {
+  it('returns the trimmed text after the command', () => {
+    expect(getLineArgs('/milestone', '/milestone v1.2')).toBe('v1.2')
+    expect(getLineArgs('/milestone', '/milestone   v1.2  ')).toBe('v1.2')
+  })
+
+  it('returns an empty string for a bare command', () => {
+    expect(getLineArgs('/milestone', '/milestone')).toBe('')
+    expect(getLineArgs('/milestone', '/milestone ')).toBe('')
+  })
+
+  it('returns an empty string when the command is absent', () => {
+    expect(getLineArgs('/milestone', 'no command here')).toBe('')
+    expect(getLineArgs('/milestone', 'set /milestone v1.2 please')).toBe('')
   })
 })

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Token used by prow actions to accomplish jobs and tasks. May be a bot user access token or the limited scope Github token
     required: true
   prow-commands:
-    description: Comment keywords/commands to look for. Space delimited. Expect commands on own line.
+    description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command.
     required: false
   jobs:
     description: The jobs to automatically run on event. Space delimited. Expect commands on own line.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1493,7 +1493,8 @@ const command_1 = __nccwpck_require__(7971);
 const octokit_1 = __nccwpck_require__(7995);
 /**
  * /milestone will add the issue to an existing milestone.
- * Note that the command should have an argument with the milestone to add
+ * Note that the command should have an argument with the milestone to add.
+ * /milestone clear removes the issue from its milestone.
  *
  * @param context - the github actions event context
  */
@@ -1522,18 +1523,28 @@ async function milestone(context = github.context) {
     if (milestoneToAdd === '') {
         throw new Error(`please provide a milestone to add`);
     }
+    if (milestoneToAdd === 'clear') {
+        await octokit.issues.update({
+            ...context.repo,
+            issue_number: issueNumber,
+            milestone: null,
+        });
+        return;
+    }
     const ms = await octokit.issues.listMilestones({
         ...context.repo,
     });
-    for (const m of ms.data) {
-        if (m.title === milestoneToAdd) {
-            await octokit.issues.update({
-                ...context.repo,
-                issue_number: issueNumber,
-                milestone: m.number,
-            });
-        }
+    const match = ms.data.find(m => m.title === milestoneToAdd);
+    if (match === undefined) {
+        const titles = ms.data.map(m => m.title);
+        const available = titles.length === 0 ? 'none' : titles.join(', ');
+        throw new Error(`milestone "${milestoneToAdd}" not found. Available milestones: ${available}`);
     }
+    await octokit.issues.update({
+        ...context.repo,
+        issue_number: issueNumber,
+        milestone: match.number,
+    });
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1010,6 +1010,7 @@ const kind_1 = __nccwpck_require__(8794);
 const lgtm_1 = __nccwpck_require__(8858);
 const priority_1 = __nccwpck_require__(5656);
 const remove_1 = __nccwpck_require__(8540);
+const command_1 = __nccwpck_require__(7971);
 const approve_1 = __nccwpck_require__(7912);
 const assign_1 = __nccwpck_require__(5371);
 const cc_1 = __nccwpck_require__(423);
@@ -1031,11 +1032,15 @@ const uncc_1 = __nccwpck_require__(6980);
 async function handleIssueComment(context = github.context) {
     const commandConfig = core
         .getInput('prow-commands', { required: false })
-        .replace(/\n/g, ' ')
-        .split(' ');
+        .split(/\s+/)
+        .filter(command => command !== '');
     const commentBody = context.payload.comment?.body;
+    if (commandConfig.length === 0) {
+        core.setFailed(`please provide a list of space delimited commands / jobs to run. None found`);
+        return;
+    }
     await Promise.all(commandConfig.map(async (command) => {
-        if (commentBody.includes(command)) {
+        if ((0, command_1.hasCommand)(command, commentBody)) {
             switch (command) {
                 case '/assign':
                     return await (0, assign_1.assign)(context).catch(normalizeError);
@@ -1071,8 +1076,6 @@ async function handleIssueComment(context = github.context) {
                     return await (0, milestone_1.milestone)(context).catch(normalizeError);
                 case '/meow':
                     return await (0, meow_1.meow)(context).catch(normalizeError);
-                case '':
-                    return new Error(`please provide a list of space delimited commands / jobs to run. None found`);
                 default:
                     return new Error(`could not execute ${command}. May not be supported - please refer to docs`);
             }
@@ -2927,24 +2930,33 @@ function isInOwnersFile(ownersContents, role, username) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.hasCommand = hasCommand;
 exports.getLineArgs = getLineArgs;
 exports.getCommandArgs = getCommandArgs;
 /**
- * getLineArgs will return the line entire line associated with a given command
- * Ex return: '/assign some-user some-other-user'
+ * hasCommand reports whether the command starts a line of the body
+ * (leading whitespace allowed) so that mentions mid-sentence and
+ * longer commands sharing a prefix (/remove-lgtm vs /lgtm) do not match
+ *
+ * @param command - the command to look for. Ex: '/assign'
+ * @param body - the full body of the comment
+ */
+function hasCommand(command, body) {
+    return findCommandLine(command, body) !== undefined;
+}
+/**
+ * getLineArgs will return the trimmed text following the command on its line
+ * Ex return: 'some-user some-other-user'
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 function getLineArgs(command, body) {
-    let toReturn = '';
-    const lineArray = splitLines(body);
-    for (const iterator of lineArray) {
-        if (iterator.includes(command)) {
-            toReturn = iterator.replace(`${command} `, '');
-        }
+    const line = findCommandLine(command, body);
+    if (line === undefined) {
+        return '';
     }
-    return toReturn;
+    return line.trim().slice(command.length).trim();
 }
 /**
  * getCommandArgs will return an array of the arguments associated with a command
@@ -2954,28 +2966,27 @@ function getLineArgs(command, body) {
  * @param body - the full body of the comment
  */
 function getCommandArgs(command, body) {
-    const toReturn = [];
-    const lineArray = splitLines(body);
-    let bodyArray;
-    for (const iterator of lineArray) {
-        if (iterator.includes(command)) {
-            bodyArray = iterator.split(' ');
-        }
-    }
-    if (bodyArray === undefined) {
+    const line = findCommandLine(command, body);
+    if (line === undefined) {
         throw new Error(`command ${command} missing from body`);
     }
-    let i = 0;
-    while (bodyArray[i] !== command && i < bodyArray.length) {
-        i++;
+    const args = line.trim().split(' ').slice(1);
+    return stripAtSign(args);
+}
+function findCommandLine(command, body) {
+    const pattern = commandPattern(command);
+    let found;
+    for (const line of splitLines(body)) {
+        if (pattern.test(line)) {
+            found = line;
+        }
     }
-    // advance the index to the next as we've found the command
-    i++;
-    while (bodyArray[i] !== '\n' && i < bodyArray.length) {
-        toReturn.push(bodyArray[i]);
-        i++;
-    }
-    return stripAtSign(toReturn);
+    return found;
+}
+function commandPattern(command) {
+    // escape regex metacharacters so a command is matched literally
+    const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`^\\s*${escaped}(\\s|$)`);
 }
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings
 function splitLines(body) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -535,8 +535,9 @@ const octokit_1 = __nccwpck_require__(7995);
  * the /approve command will create a "approve" review
  * from the github-actions bot
  *
- * If the argument 'cancel' is provided to the /approve command
- * the last review will be removed
+ * If the argument 'cancel' is provided to the /approve command,
+ * or /remove-approve is used, the last review will be removed.
+ * The Prow argument 'no-issue' is accepted and behaves like a plain /approve.
  *
  * @param context - the github actions event context
  */
@@ -566,9 +567,9 @@ async function approve(context = github.context) {
         }
         throw e;
     }
-    const commentArgs = (0, command_1.getCommandArgs)('/approve', commentBody);
-    // check if canceling last review
-    if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+    const isCancel = (0, command_1.hasCommand)('/remove-approve', commentBody)
+        || ((0, command_1.hasCommand)('/approve', commentBody) && (0, command_1.getCommandArgs)('/approve', commentBody)[0] === 'cancel');
+    if (isCancel) {
         try {
             await cancel(octokit, context, issueNumber, commenterLogin);
         }
@@ -1022,6 +1023,23 @@ const reopen_1 = __nccwpck_require__(1328);
 const retitle_1 = __nccwpck_require__(7068);
 const unassign_1 = __nccwpck_require__(5647);
 const uncc_1 = __nccwpck_require__(6980);
+// Prow-style spellings that are handled by the canonical command's module
+const commandAliases = {
+    '/lgtm': ['/remove-lgtm'],
+    '/approve': ['/remove-approve'],
+    '/hold': ['/unhold', '/remove-hold'],
+};
+function canonicalCommand(name) {
+    for (const [command, aliases] of Object.entries(commandAliases)) {
+        if (aliases.includes(name)) {
+            return command;
+        }
+    }
+    return name;
+}
+function commandForms(command) {
+    return [command, ...(commandAliases[command] ?? [])];
+}
 /**
  * This Method handles any issue comments
  * Note that the github api considers PRs issues
@@ -1030,17 +1048,18 @@ const uncc_1 = __nccwpck_require__(6980);
  * @param context - the github context of the current action event
  */
 async function handleIssueComment(context = github.context) {
-    const commandConfig = core
-        .getInput('prow-commands', { required: false })
-        .split(/\s+/)
-        .filter(command => command !== '');
+    const commandConfig = [...new Set(core
+            .getInput('prow-commands', { required: false })
+            .split(/\s+/)
+            .filter(command => command !== '')
+            .map(canonicalCommand))];
     const commentBody = context.payload.comment?.body;
     if (commandConfig.length === 0) {
         core.setFailed(`please provide a list of space delimited commands / jobs to run. None found`);
         return;
     }
     await Promise.all(commandConfig.map(async (command) => {
-        if ((0, command_1.hasCommand)(command, commentBody)) {
+        if (commandForms(command).some(form => (0, command_1.hasCommand)(form, commentBody))) {
             switch (command) {
                 case '/assign':
                     return await (0, assign_1.assign)(context).catch(normalizeError);
@@ -2030,7 +2049,8 @@ const command_1 = __nccwpck_require__(7971);
 const labeling_1 = __nccwpck_require__(7138);
 const octokit_1 = __nccwpck_require__(7995);
 /**
- * /hold will add the hold label
+ * /hold will add the hold label.
+ * /hold cancel, /unhold and /remove-hold remove it.
  * Note - the hold label will block automatic merging if the lgtm
  * is also present
  *
@@ -2044,9 +2064,10 @@ async function hold(context = github.context) {
     if (issueNumber === undefined) {
         throw new Error(`github context payload missing issue number: ${context.payload}`);
     }
-    const commentArgs = (0, command_1.getCommandArgs)('/hold', commentBody);
-    // check if canceling last review
-    if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+    const cancel = (0, command_1.hasCommand)('/unhold', commentBody)
+        || (0, command_1.hasCommand)('/remove-hold', commentBody)
+        || ((0, command_1.hasCommand)('/hold', commentBody) && (0, command_1.getCommandArgs)('/hold', commentBody)[0] === 'cancel');
+    if (cancel) {
         try {
             await (0, labeling_1.cancelLabel)(octokit, context, issueNumber, 'hold');
         }
@@ -2191,6 +2212,7 @@ const labeling_1 = __nccwpck_require__(7138);
 const octokit_1 = __nccwpck_require__(7995);
 /**
  * /lgtm will add the lgtm label.
+ * /lgtm cancel and /remove-lgtm remove it.
  * Note - this label is used to indicate automatic merging
  * if the user has configured a cron job to perform automatic merging
  *
@@ -2221,9 +2243,9 @@ async function lgtm(context = github.context) {
         }
         throw e;
     }
-    const commentArgs = (0, command_1.getCommandArgs)('/lgtm', commentBody);
-    // check if canceling last review
-    if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+    const cancel = (0, command_1.hasCommand)('/remove-lgtm', commentBody)
+        || ((0, command_1.hasCommand)('/lgtm', commentBody) && (0, command_1.getCommandArgs)('/lgtm', commentBody)[0] === 'cancel');
+    if (cancel) {
         try {
             await (0, labeling_1.cancelLabel)(octokit, context, issueNumber, 'lgtm');
         }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,9 +1,13 @@
 # Prow github actions commands
 
+A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command.
+
 Commands | Policy | Description
 --- | --- | ---
 `/approve` | [OWNERS](#owners) if present, otherwise Org members & Collaborators | approve all the files for the current PR
+`/approve no-issue` | [OWNERS](#owners) if present, otherwise Org members & Collaborators | same as `/approve`; accepted for Prow compatibility
 `/approve cancel` | [OWNERS](#owners) if present, otherwise Org member & Collaborators | removes your approval on this pull-request
+`/remove-approve` | [OWNERS](#owners) if present, otherwise Org member & Collaborators | same as `/approve cancel`
 `/assign [@userA @userB @etc]` | anyone | Assign other users (or yourself if no one is specified). Target user must be Org Member, Collaborator, or have previously commented
 `/unassign [@userA @userB @etc]` | anyone | Unassigns specified people (or yourself if no one is specified). Target must have been already assigned.
 `/cc [@userA @userB @etc]` | anyone | Request review from specified people (or yourself if no one is specified). Target be an Org Member, Collaborator, or have previously commented.
@@ -21,8 +25,10 @@ Label Commands | Policy | Description
 `/kind [label1 label2 ...]` | anyone | adds a kind/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
 `/lgtm` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | adds the `lgtm` label. This is used for [automatic PR merging](./automatic-merging.md)
 `/lgtm cancel` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | removes the `lgtm` label
+`/remove-lgtm` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | same as `/lgtm cancel`
 `/hold` | anyone | adds the `hold` label which prevents [automatic PR merging](./automatic-merging.md). Also see [lgtm removal on pr update](./pr-jobs.md)
 `/hold cancel` | anyone | removes the `hold` label
+`/unhold`, `/remove-hold` | anyone | same as `/hold cancel`
 `/priority [label1 label2 ...]` | anyone | adds a priority/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md). Replaces any existing `priority/*` labels.
 `/remove [label1 label2 ...]` | Collaborators | removes a specified label(s) on an issue / PR
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,7 +15,8 @@ Commands | Policy | Description
 `/close` | Collaborators | closes the issue / PR
 `/reopen` | Collaborators | reopens a closed issue / PR
 `/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason
-`/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone
+`/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone. An unknown title fails the run with the list of available milestones
+`/milestone clear` | Collaborators | Removes the issue / PR from its milestone
 `/retitle some new title` | Collaborators | Renames the issue / PR
 `/meow` | anyone | replies with a random cat image from [the cat API](https://thecatapi.com)
 

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -4,7 +4,7 @@ import type { Octokit, RestEndpointMethodTypes } from '@octokit/rest'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { getCommandArgs } from '../utils/command'
+import { getCommandArgs, hasCommand } from '../utils/command'
 import { createComment } from '../utils/comments'
 import { newOctokit } from '../utils/octokit'
 
@@ -15,8 +15,9 @@ type PullsListReviewsResponseType
  * the /approve command will create a "approve" review
  * from the github-actions bot
  *
- * If the argument 'cancel' is provided to the /approve command
- * the last review will be removed
+ * If the argument 'cancel' is provided to the /approve command,
+ * or /remove-approve is used, the last review will be removed.
+ * The Prow argument 'no-issue' is accepted and behaves like a plain /approve.
  *
  * @param context - the github actions event context
  */
@@ -60,10 +61,10 @@ export async function approve(
     throw e
   }
 
-  const commentArgs: string[] = getCommandArgs('/approve', commentBody)
+  const isCancel = hasCommand('/remove-approve', commentBody)
+    || (hasCommand('/approve', commentBody) && getCommandArgs('/approve', commentBody)[0] === 'cancel')
 
-  // check if canceling last review
-  if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+  if (isCancel) {
     try {
       await cancel(octokit, context, issueNumber, commenterLogin)
     }

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -22,6 +22,26 @@ import { retitle } from './retitle'
 import { unassign } from './unassign'
 import { uncc } from './uncc'
 
+// Prow-style spellings that are handled by the canonical command's module
+const commandAliases: Record<string, string[]> = {
+  '/lgtm': ['/remove-lgtm'],
+  '/approve': ['/remove-approve'],
+  '/hold': ['/unhold', '/remove-hold'],
+}
+
+function canonicalCommand(name: string): string {
+  for (const [command, aliases] of Object.entries(commandAliases)) {
+    if (aliases.includes(name)) {
+      return command
+    }
+  }
+  return name
+}
+
+function commandForms(command: string): string[] {
+  return [command, ...(commandAliases[command] ?? [])]
+}
+
 /**
  * This Method handles any issue comments
  * Note that the github api considers PRs issues
@@ -30,10 +50,13 @@ import { uncc } from './uncc'
  * @param context - the github context of the current action event
  */
 export async function handleIssueComment(context: Context = github.context): Promise<void> {
-  const commandConfig = core
-    .getInput('prow-commands', { required: false })
-    .split(/\s+/)
-    .filter(command => command !== '')
+  const commandConfig = [...new Set(
+    core
+      .getInput('prow-commands', { required: false })
+      .split(/\s+/)
+      .filter(command => command !== '')
+      .map(canonicalCommand),
+  )]
   const commentBody: string = context.payload.comment?.body
 
   if (commandConfig.length === 0) {
@@ -45,7 +68,7 @@ export async function handleIssueComment(context: Context = github.context): Pro
 
   await Promise.all(
     commandConfig.map(async (command) => {
-      if (hasCommand(command, commentBody)) {
+      if (commandForms(command).some(form => hasCommand(form, commentBody))) {
         switch (command) {
           case '/assign':
             return await assign(context).catch(normalizeError)

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -9,6 +9,7 @@ import { kind } from '../labels/kind'
 import { lgtm } from '../labels/lgtm'
 import { priority } from '../labels/priority'
 import { remove } from '../labels/remove'
+import { hasCommand } from '../utils/command'
 import { approve } from './approve'
 import { assign } from './assign'
 import { cc } from './cc'
@@ -31,13 +32,20 @@ import { uncc } from './uncc'
 export async function handleIssueComment(context: Context = github.context): Promise<void> {
   const commandConfig = core
     .getInput('prow-commands', { required: false })
-    .replace(/\n/g, ' ')
-    .split(' ')
+    .split(/\s+/)
+    .filter(command => command !== '')
   const commentBody: string = context.payload.comment?.body
+
+  if (commandConfig.length === 0) {
+    core.setFailed(
+      `please provide a list of space delimited commands / jobs to run. None found`,
+    )
+    return
+  }
 
   await Promise.all(
     commandConfig.map(async (command) => {
-      if (commentBody.includes(command)) {
+      if (hasCommand(command, commentBody)) {
         switch (command) {
           case '/assign':
             return await assign(context).catch(normalizeError)
@@ -89,11 +97,6 @@ export async function handleIssueComment(context: Context = github.context): Pro
 
           case '/meow':
             return await meow(context).catch(normalizeError)
-
-          case '':
-            return new Error(
-              `please provide a list of space delimited commands / jobs to run. None found`,
-            )
 
           default:
             return new Error(

--- a/src/issueComment/milestone.ts
+++ b/src/issueComment/milestone.ts
@@ -9,7 +9,8 @@ import { newOctokit } from '../utils/octokit'
 
 /**
  * /milestone will add the issue to an existing milestone.
- * Note that the command should have an argument with the milestone to add
+ * Note that the command should have an argument with the milestone to add.
+ * /milestone clear removes the issue from its milestone.
  *
  * @param context - the github actions event context
  */
@@ -51,17 +52,32 @@ export async function milestone(
     throw new Error(`please provide a milestone to add`)
   }
 
+  if (milestoneToAdd === 'clear') {
+    await octokit.issues.update({
+      ...context.repo,
+      issue_number: issueNumber,
+      milestone: null,
+    })
+    return
+  }
+
   const ms = await octokit.issues.listMilestones({
     ...context.repo,
   })
 
-  for (const m of ms.data) {
-    if (m.title === milestoneToAdd) {
-      await octokit.issues.update({
-        ...context.repo,
-        issue_number: issueNumber,
-        milestone: m.number,
-      })
-    }
+  const match = ms.data.find(m => m.title === milestoneToAdd)
+
+  if (match === undefined) {
+    const titles = ms.data.map(m => m.title)
+    const available = titles.length === 0 ? 'none' : titles.join(', ')
+    throw new Error(
+      `milestone "${milestoneToAdd}" not found. Available milestones: ${available}`,
+    )
   }
+
+  await octokit.issues.update({
+    ...context.repo,
+    issue_number: issueNumber,
+    milestone: match.number,
+  })
 }

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -3,12 +3,13 @@ import * as core from '@actions/core'
 
 import * as github from '@actions/github'
 
-import { getCommandArgs } from '../utils/command'
+import { getCommandArgs, hasCommand } from '../utils/command'
 import { cancelLabel, labelIssue } from '../utils/labeling'
 import { newOctokit } from '../utils/octokit'
 
 /**
- * /hold will add the hold label
+ * /hold will add the hold label.
+ * /hold cancel, /unhold and /remove-hold remove it.
  * Note - the hold label will block automatic merging if the lgtm
  * is also present
  *
@@ -27,10 +28,11 @@ export async function hold(context: Context = github.context): Promise<void> {
     )
   }
 
-  const commentArgs: string[] = getCommandArgs('/hold', commentBody)
+  const cancel = hasCommand('/unhold', commentBody)
+    || hasCommand('/remove-hold', commentBody)
+    || (hasCommand('/hold', commentBody) && getCommandArgs('/hold', commentBody)[0] === 'cancel')
 
-  // check if canceling last review
-  if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+  if (cancel) {
     try {
       await cancelLabel(octokit, context, issueNumber, 'hold')
     }

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -4,13 +4,14 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { getCommandArgs } from '../utils/command'
+import { getCommandArgs, hasCommand } from '../utils/command'
 import { createComment } from '../utils/comments'
 import { cancelLabel, labelIssue } from '../utils/labeling'
 import { newOctokit } from '../utils/octokit'
 
 /**
  * /lgtm will add the lgtm label.
+ * /lgtm cancel and /remove-lgtm remove it.
  * Note - this label is used to indicate automatic merging
  * if the user has configured a cron job to perform automatic merging
  *
@@ -53,10 +54,10 @@ export async function lgtm(context: Context = github.context): Promise<void> {
     throw e
   }
 
-  const commentArgs: string[] = getCommandArgs('/lgtm', commentBody)
+  const cancel = hasCommand('/remove-lgtm', commentBody)
+    || (hasCommand('/lgtm', commentBody) && getCommandArgs('/lgtm', commentBody)[0] === 'cancel')
 
-  // check if canceling last review
-  if (commentArgs.length !== 0 && commentArgs[0] === 'cancel') {
+  if (cancel) {
     try {
       await cancelLabel(octokit, context, issueNumber, 'lgtm')
     }

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -1,21 +1,29 @@
 /**
- * getLineArgs will return the line entire line associated with a given command
- * Ex return: '/assign some-user some-other-user'
+ * hasCommand reports whether the command starts a line of the body
+ * (leading whitespace allowed) so that mentions mid-sentence and
+ * longer commands sharing a prefix (/remove-lgtm vs /lgtm) do not match
+ *
+ * @param command - the command to look for. Ex: '/assign'
+ * @param body - the full body of the comment
+ */
+export function hasCommand(command: string, body: string): boolean {
+  return findCommandLine(command, body) !== undefined
+}
+
+/**
+ * getLineArgs will return the trimmed text following the command on its line
+ * Ex return: 'some-user some-other-user'
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 export function getLineArgs(command: string, body: string): string {
-  let toReturn = ''
-  const lineArray = splitLines(body)
-
-  for (const iterator of lineArray) {
-    if (iterator.includes(command)) {
-      toReturn = iterator.replace(`${command} `, '')
-    }
+  const line = findCommandLine(command, body)
+  if (line === undefined) {
+    return ''
   }
 
-  return toReturn
+  return line.trim().slice(command.length).trim()
 }
 
 /**
@@ -26,33 +34,34 @@ export function getLineArgs(command: string, body: string): string {
  * @param body - the full body of the comment
  */
 export function getCommandArgs(command: string, body: string): string[] {
-  const toReturn = []
-  const lineArray = splitLines(body)
-  let bodyArray
+  const line = findCommandLine(command, body)
 
-  for (const iterator of lineArray) {
-    if (iterator.includes(command)) {
-      bodyArray = iterator.split(' ')
-    }
-  }
-
-  if (bodyArray === undefined) {
+  if (line === undefined) {
     throw new Error(`command ${command} missing from body`)
   }
 
-  let i = 0
-  while (bodyArray[i] !== command && i < bodyArray.length) {
-    i++
+  const args = line.trim().split(' ').slice(1)
+
+  return stripAtSign(args)
+}
+
+function findCommandLine(command: string, body: string): string | undefined {
+  const pattern = commandPattern(command)
+  let found: string | undefined
+
+  for (const line of splitLines(body)) {
+    if (pattern.test(line)) {
+      found = line
+    }
   }
 
-  // advance the index to the next as we've found the command
-  i++
-  while (bodyArray[i] !== '\n' && i < bodyArray.length) {
-    toReturn.push(bodyArray[i])
-    i++
-  }
+  return found
+}
 
-  return stripAtSign(toReturn)
+function commandPattern(command: string): RegExp {
+  // escape regex metacharacters so a command is matched literally
+  const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^\\s*${escaped}(\\s|$)`)
 }
 
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings


### PR DESCRIPTION
# Description

Brings four commands to parity with Prow's grammar ([command-help](https://prow.k8s.io/command-help)), and fixes the command matcher so this is possible.

| Prow | Now supported |
|---|---|
| `/[remove-]lgtm [cancel]` | `/remove-lgtm` ≡ `/lgtm cancel` |
| `/[remove-]approve [no-issue\|cancel]` | `/remove-approve` ≡ `/approve cancel`; `/approve no-issue` ≡ `/approve` |
| `/[remove-][un]hold [cancel]` | `/unhold` ≡ `/remove-hold` ≡ `/hold cancel` |
| `/milestone <version>` / `/milestone clear` | `/milestone clear` removes the milestone; an unknown title now **fails with the list of available milestones** instead of silently doing nothing |

Aliases are enabled together with their base command in `prow-commands` (listing `/unhold` directly also works — it resolves to `/hold`). Authorization is unchanged for every path.

## `fix: match commands only at the start of a line`
The dispatcher and `getCommandArgs`/`getLineArgs` used substring `includes`, so `/remove-lgtm` would have dispatched `/lgtm` (and *added* the label), and "please don't /hold this" fired `/hold`. Commands now match `^\s*<command>(\s|$)` per line — which is what `action.yml` and the docs have always said ("expect commands on own line"). Also: a doubled space in `prow-commands` used to produce an empty command that matched every comment and failed the run; the config is now split on whitespace with empties dropped.

This closes the mid-sentence part of #66; fenced code blocks are still not stripped (left for a follow-up, not claimed fixed).

# Testing
- [x] `npm run all` green — **29 files, 223 tests** (was 185); coverage 88.8 / 89.6 br / 97.0 fn
- [x] New bundle-harness scenario: `/unhold` against the committed `dist/index.js`
- [x] Hermetic under a simulated Actions env
- [x] `dist/` regenerated, byte-identical across repeated packs
