### PR TITLE
fix(command): unify matcher and tokenizer; apply every command line; pin #132/#133 edge cases

### DIFF
--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -184,6 +184,28 @@ describe('dist/index.js', () => {
     ])
   })
 
+  it('issue_comment /milestone clear unsets the milestone for a collaborator', async () => {
+    gh.route('GET', `${repo}/collaborators/Codertocat`, { status: 204 })
+    gh.route('PATCH', `${repo}/issues/1`, { status: 200, body: {} })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/milestone clear'),
+      inputs: { ...token, 'prow-commands': '/milestone' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    const patches = gh.requestsMatching('PATCH', /\/issues\/1$/)
+    expect(patches).toHaveLength(1)
+    expect(patches[0].body).toEqual({ milestone: null })
+    expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      `GET ${repo}/collaborators/Codertocat`,
+      `PATCH ${repo}/issues/1`,
+    ])
+  })
+
   it('issue_comment /unhold removes the hold label when /hold is configured', async () => {
     gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'hold' }] } })
     gh.route('DELETE', `${repo}/issues/1/labels/hold`, { status: 200, body: [] })

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -388,6 +388,105 @@ reviewers:
     })
   })
 
+  it('approves with /approve no-issue if commenter is an approver in OWNERS', async () => {
+    const owners = Buffer.from(
+      `
+    approvers:
+    - Codertocat
+        `,
+    ).toString('base64')
+
+    const contentResponse = {
+      type: 'file',
+      encoding: 'base64',
+      size: 4096,
+      name: 'OWNERS',
+      path: 'OWNERS',
+      content: owners,
+    }
+    const observeMembers = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(200, contentResponse),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204, null, observeMembers),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/approve no-issue'
+    issueCommentEventAssign.comment.user.login = 'Codertocat'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toMatchObject({
+      event: 'APPROVE',
+    })
+    await expect(observeMembers.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails /remove-approve when the bot has no approved review', async () => {
+    const reviews = structuredClone(pullReqListReviews)
+    reviews[0].state = 'COMMENTED'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, reviews),
+      ),
+    )
+
+    const observeDismiss = new utils.ObserveRequest()
+    const observeCreate = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeDismiss),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeCreate),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = '/remove-approve'
+    issueCommentEventAssign.comment.user.login = 'some-user'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDismiss.notCalled()).resolves.toBe('not called')
+    await expect(observeCreate.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('no latest review found to cancel'),
+    )
+  })
+
   it.each([
     ['/approve\n/approve cancel'],
     ['/approve cancel\n/approve'],

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -388,6 +388,53 @@ reviewers:
     })
   })
 
+  it.each([
+    ['/approve\n/approve cancel'],
+    ['/approve cancel\n/approve'],
+  ])('cancel wins when a comment carries both /approve and /approve cancel: %j', async (body) => {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, pullReqListReviews),
+      ),
+    )
+
+    const observeDismiss = new utils.ObserveRequest()
+    const observeCreate = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews/80/dismissals`,
+        utils.mockResponse(200, null, observeDismiss),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/1/reviews`,
+        utils.mockResponse(200, null, observeCreate),
+      ),
+    )
+
+    issueCommentEventAssign.comment.body = body
+    issueCommentEventAssign.comment.user.login = 'some-user'
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDismiss.called()).resolves.toBe('called')
+    await expect(observeCreate.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('removes approval with the /approve cancel command if commenter is collaborator', async () => {
     server.use(
       http.get(

--- a/__tests__/issueCommentTest/assign.test.ts
+++ b/__tests__/issueCommentTest/assign.test.ts
@@ -170,6 +170,51 @@ describe('/assign', () => {
     })
   })
 
+  it('assigns users from every /assign line in the comment', async () => {
+    issueCommentEventAssign.comment.body = '/assign @some-user\nplease also take a look\n/assign @other-user'
+
+    server.use(
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/some-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/other-user`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/some-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/other-user`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/assignees`,
+        utils.mockResponse(201, issueAssignedResp, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEventAssign)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      assignees: ['some-user', 'other-user'],
+    })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('assigns user if they are an org member', async () => {
     issueCommentEventAssign.comment.body = '/assign @some-user'
 

--- a/__tests__/issueCommentTest/handleIssueComment.test.ts
+++ b/__tests__/issueCommentTest/handleIssueComment.test.ts
@@ -223,6 +223,41 @@ it('runs a command once when both it and an alias are configured', async () => {
   expect(hold.hold).toHaveBeenCalledTimes(1)
 })
 
+it('listing only /remove-kind also enables /kind', async () => {
+  utils.setupActionsEnv('/remove-kind')
+
+  const add = vi.spyOn(prefixed, 'addPrefixedLabels').mockImplementation(() => Promise.resolve())
+  const remove = vi.spyOn(prefixed, 'removePrefixedLabels').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/kind cleanup'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(add).toHaveBeenCalledTimes(1)
+  expect(add.mock.calls[0][1]).toMatchObject({ command: '/kind' })
+  expect(remove).not.toHaveBeenCalled()
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it.each([
+  ['/remove-lgtm', '/lgtm', lgtm, 'lgtm'],
+  ['/unhold', '/hold', hold, 'hold'],
+  ['/remove-approve', '/approve', approve, 'approve'],
+] as const)('listing only %s also enables %s', async (alias, base, mod, fn) => {
+  utils.setupActionsEnv(alias)
+
+  const spy = vi.spyOn(mod, fn).mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = base
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(spy).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
 it('does not dispatch an alias whose base command is not configured', async () => {
   utils.setupActionsEnv('/assign')
 
@@ -284,4 +319,20 @@ it('does not dispatch /remove-kind when /kind is not configured', async () => {
   await handleIssueComment(context)
   expect(add).not.toHaveBeenCalled()
   expect(remove).not.toHaveBeenCalled()
+})
+
+it.each(['/area', '/kind', '/priority', '/label'])('ignores a lone /remove-%s alias when %s is not configured', async (command) => {
+  utils.setupActionsEnv(command === '/kind' ? '/area' : '/kind')
+
+  const add = vi.spyOn(prefixed, 'addPrefixedLabels').mockImplementation(() => Promise.resolve())
+  const remove = vi.spyOn(prefixed, 'removePrefixedLabels').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = `${prefixed.removeCommandFor(command)} x`
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(add).not.toHaveBeenCalled()
+  expect(remove).not.toHaveBeenCalled()
+  expect(setFailed).not.toHaveBeenCalled()
 })

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -166,6 +166,43 @@ describe('/milestone', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it('still sends the clear when the issue has no milestone', async () => {
+    const payload = structuredClone(issueCommentEvent) as typeof issueCommentEvent & { issue: { milestone: unknown } }
+    payload.comment.body = '/milestone clear'
+    payload.issue.milestone = null
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    const observeList = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones, observeList),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(payload)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      milestone: null,
+    })
+    await expect(observeList.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('does not clear the milestone when commenter is not a collaborator', async () => {
     issueCommentEvent.comment.body = '/milestone clear'
 

--- a/__tests__/issueCommentTest/retitle.test.ts
+++ b/__tests__/issueCommentTest/retitle.test.ts
@@ -50,6 +50,33 @@ describe('/retitle', () => {
     })
   })
 
+  it('keeps repeated words and uses the last /retitle line', async () => {
+    issueCommentEvent.comment.body = '/retitle first attempt\n/retitle fix the bug in the parser'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      title: 'fix the bug in the parser',
+    })
+  })
+
   it('does not retitle when commenter is not a collaborator', async () => {
     issueCommentEvent.comment.body = '/retitle much better title'
 

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -97,6 +97,40 @@ describe('hold', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['/hold\n/hold cancel'],
+    ['/hold cancel\n/hold'],
+  ])('cancel wins when a comment carries both /hold and /hold cancel: %j', async (body) => {
+    issueCommentEvent.comment.body = body
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({ ...payload.labels[0], name: 'hold' })
+
+    const observeReqDelete = new utils.ObserveRequest()
+    const observeReqAdd = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/hold`,
+        utils.mockResponse(200, null, observeReqDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReqAdd),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReqDelete.called()).resolves.toBe('called')
+    await expect(observeReqAdd.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it.each(['/unhold', '/remove-hold'])('removes the hold label with %s', async (body) => {
     issueCommentEvent.comment.body = body
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -305,4 +305,77 @@ describe('kind', () => {
     })
     expect(setFailed).not.toHaveBeenCalled()
   })
+
+  it('still posts /kind when the label is already on the issue and never deletes', async () => {
+    issueCommentEvent.comment.body = '/kind cleanup'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const mutations: string[] = []
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/:name`,
+        async ({ request }) => {
+          mutations.push(`DELETE ${new URL(request.url).pathname.split('/labels/')[1]}`)
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        async ({ request }) => {
+          const body = await request.json() as { labels: string[] }
+          mutations.push(`POST ${body.labels.join(',')}`)
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issueWithLabels('kind/cleanup')),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(mutations).toEqual(['POST kind/cleanup'])
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('deletes exactly the requested kind label when several are on the issue', async () => {
+    issueCommentEvent.comment.body = '/remove-kind cleanup'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const mutations: string[] = []
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/:name`,
+        async ({ request }) => {
+          mutations.push(`DELETE ${new URL(request.url).pathname.split('/labels/')[1]}`)
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        async () => {
+          mutations.push('POST')
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issueWithLabels('kind/cleanup', 'kind/failing-test')),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(mutations).toEqual(['DELETE kind%2Fcleanup'])
+    expect(setFailed).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -84,6 +84,31 @@ describe('kind', () => {
     })
   })
 
+  it('applies every /kind line in the comment', async () => {
+    issueCommentEvent.comment.body = '/kind cleanup\nsome context\n/kind failing-test'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      labels: ['kind/cleanup', 'kind/failing-test'],
+    })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('only adds kind labels for files in .prowlabels.yaml', async () => {
     issueCommentEvent.comment.body = '/kind cleanup bad failing-test'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/label.test.ts
+++ b/__tests__/label/label.test.ts
@@ -216,6 +216,69 @@ describe('label', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it('adds an allowlisted label containing a slash verbatim', async () => {
+    issueCommentEvent.comment.body = '/label tide/merge-method-squash'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const withSlash = structuredClone(labelFileContents)
+    withSlash.content = Buffer.from('labels:\n  - tide/merge-method-squash\n').toString('base64')
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, withSlash),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      labels: ['tide/merge-method-squash'],
+    })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('removes an allowlisted label containing a slash with /remove-label', async () => {
+    issueCommentEvent.comment.body = '/remove-label tide/merge-method-squash'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const withSlash = structuredClone(labelFileContents)
+    withSlash.content = Buffer.from('labels:\n  - tide/merge-method-squash\n').toString('base64')
+
+    const observeDelete = new utils.ObserveRequest()
+    const observePost = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/tide%2Fmerge-method-squash`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observePost),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issueWithLabels('tide/merge-method-squash')),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, withSlash),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDelete.called()).resolves.toBe('called')
+    await expect(observePost.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('handles /label and /remove-label in the same comment', async () => {
     issueCommentEvent.comment.body = '/label good-first-issue\n/remove-label help-wanted'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -228,6 +228,52 @@ describe('lgtm', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it.each([
+    ['/lgtm\n/lgtm cancel'],
+    ['/lgtm cancel\n/lgtm'],
+  ])('cancel wins when a comment carries both /lgtm and /lgtm cancel: %j', async (body) => {
+    issueCommentEvent.comment.body = body
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+
+    const observeDelete = new utils.ObserveRequest()
+    const observeAdd = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeAdd),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDelete.called()).resolves.toBe('called')
+    await expect(observeAdd.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('adds label if commenter is collaborator', async () => {
     issueCommentEvent.comment.body = '/lgtm'
     const commentContext = new utils.MockContext(issueCommentEvent)

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -383,4 +383,47 @@ describe('priority', () => {
     })
     expect(setFailed).not.toHaveBeenCalled()
   })
+
+  it('removes then re-adds when /priority high low and /remove-priority high share a comment', async () => {
+    issueCommentEvent.comment.body = '/priority high low\n/remove-priority high'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({ ...payload.labels[0], name: 'priority/high' })
+
+    const mutations: string[] = []
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/:name`,
+        async ({ request }) => {
+          mutations.push(`DELETE ${new URL(request.url).pathname.split('/labels/')[1]}`)
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        async ({ request }) => {
+          const body = await request.json() as { labels: string[] }
+          mutations.push(`POST ${body.labels.join(',')}`)
+          return new Response(null, { status: 200 })
+        },
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, labelFileContents),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    expect(mutations).toEqual([
+      'DELETE priority%2Fhigh',
+      'POST priority/high,priority/low',
+    ])
+    expect(setFailed).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -97,6 +97,52 @@ describe('anchored argument parsing', () => {
   })
 })
 
+// the matcher accepts any whitespace after the command, so the tokenizer must too
+describe('whitespace between command and arguments', () => {
+  it('splits arguments on a tab', () => {
+    expect(hasCommand('/kind', '/kind\tbug')).toBe(true)
+    expect(getCommandArgs('/kind', '/kind\tbug')).toEqual(['bug'])
+    expect(getCommandArgs('/kind', '/kind\tbug\tcleanup')).toEqual(['bug', 'cleanup'])
+  })
+
+  it('does not leak an empty argument for multiple spaces', () => {
+    expect(getCommandArgs('/kind', '/kind  bug')).toEqual(['bug'])
+    expect(getCommandArgs('/kind', '/kind   bug    cleanup')).toEqual(['bug', 'cleanup'])
+  })
+
+  it('tolerates a non-breaking space before the command', () => {
+    expect(hasCommand('/kind', '\u00A0/kind bug')).toBe(true)
+    expect(getCommandArgs('/kind', '\u00A0/kind bug')).toEqual(['bug'])
+  })
+
+  it('splits arguments on a non-breaking space', () => {
+    expect(hasCommand('/kind', '/kind\u00A0bug')).toBe(true)
+    expect(getCommandArgs('/kind', '/kind\u00A0bug')).toEqual(['bug'])
+  })
+
+  it('ignores trailing whitespace on the line', () => {
+    expect(getCommandArgs('/kind', '/kind bug   ')).toEqual(['bug'])
+    expect(getCommandArgs('/kind', '/kind bug\t')).toEqual(['bug'])
+    expect(getCommandArgs('/lgtm', '/lgtm   ')).toEqual([])
+  })
+
+  it('handles CRLF endings with tabs and extra spaces', () => {
+    const body = '/kind\tbug\r\n/area  important \r\n'
+
+    expect(getCommandArgs('/kind', body)).toEqual(['bug'])
+    expect(getCommandArgs('/area', body)).toEqual(['important'])
+  })
+
+  it('still strips a leading @ from tab separated arguments', () => {
+    expect(getCommandArgs('/assign', '/assign\t@some-user  @other-user')).toEqual(['some-user', 'other-user'])
+  })
+
+  it('applies the same tokenization to getLineArgs', () => {
+    expect(getLineArgs('/milestone', '/milestone\tv1.2')).toBe('v1.2')
+    expect(getLineArgs('/milestone', '\u00A0/milestone v1.2  ')).toBe('v1.2')
+  })
+})
+
 describe('getLineArgs', () => {
   it('returns the trimmed text after the command', () => {
     expect(getLineArgs('/milestone', '/milestone v1.2')).toBe('v1.2')

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -66,6 +66,21 @@ describe('hasCommand', () => {
     expect(hasCommand('/a.b', '/a.b')).toBe(true)
     expect(hasCommand('/a.b', '/axb')).toBe(false)
   })
+
+  it('does not match a command that is a prefix of another word', () => {
+    expect(hasCommand('/label', '/labels foo')).toBe(false)
+    expect(hasCommand('/label', '/label foo')).toBe(true)
+    expect(hasCommand('/kind', '/kind/foo')).toBe(false)
+    expect(hasCommand('/kind', '/kind foo')).toBe(true)
+  })
+
+  // #66 fenced code blocks are not stripped yet; flip this when that lands
+  it('currently matches a command inside a fenced code block', () => {
+    const body = 'try this:\n```\n/kind bug\n```\n'
+
+    expect(hasCommand('/kind', body)).toBe(true)
+    expect(getCommandArgs('/kind', body)).toEqual(['bug'])
+  })
 })
 
 describe('anchored argument parsing', () => {

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -86,14 +86,41 @@ describe('anchored argument parsing', () => {
     expect(getLineArgs('/milestone', '  /milestone v1.2')).toBe('v1.2')
   })
 
-  it('uses the last matching line', () => {
+  it('collects arguments from every matching line', () => {
     const body = '/lgtm cancel\nchanged my mind\n/lgtm'
 
-    expect(getCommandArgs('/lgtm', body)).toMatchObject([])
+    expect(getCommandArgs('/lgtm', body)).toEqual(['cancel'])
   })
 
   it('returns no arguments for a bare command', () => {
     expect(getCommandArgs('/lgtm', '/lgtm')).toMatchObject([])
+  })
+})
+
+describe('repeated command lines', () => {
+  it('concatenates arguments in order of appearance', () => {
+    const body = '/kind bug\nsome context\n/kind cleanup'
+
+    expect(getCommandArgs('/kind', body)).toEqual(['bug', 'cleanup'])
+  })
+
+  it('de-duplicates repeated arguments', () => {
+    const body = '/assign @a @b\n/assign b @c\n/assign a'
+
+    expect(getCommandArgs('/assign', body)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not collect arguments from a longer command sharing the prefix', () => {
+    const body = '/kind bug\n/remove-kind cleanup'
+
+    expect(getCommandArgs('/kind', body)).toEqual(['bug'])
+    expect(getCommandArgs('/remove-kind', body)).toEqual(['cleanup'])
+  })
+
+  it('keeps getLineArgs single valued with the last line winning', () => {
+    const body = '/milestone v1.0\n/milestone v2.0'
+
+    expect(getLineArgs('/milestone', body)).toBe('v2.0')
   })
 })
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: Token used by prow actions to accomplish jobs and tasks. May be a bot user access token or the limited scope Github token
     required: true
   prow-commands:
-    description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command.
+    description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command, and listing an alias enables the whole command family (e.g. /remove-kind also enables /kind).
     required: false
   jobs:
     description: The jobs to automatically run on event. Space delimited. Expect commands on own line.

--- a/dist/index.js
+++ b/dist/index.js
@@ -568,7 +568,7 @@ async function approve(context = github.context) {
         throw e;
     }
     const isCancel = (0, command_1.hasCommand)('/remove-approve', commentBody)
-        || ((0, command_1.hasCommand)('/approve', commentBody) && (0, command_1.getCommandArgs)('/approve', commentBody)[0] === 'cancel');
+        || ((0, command_1.hasCommand)('/approve', commentBody) && (0, command_1.getCommandArgs)('/approve', commentBody).includes('cancel'));
     if (isCancel) {
         try {
             await cancel(octokit, context, issueNumber, commenterLogin);
@@ -1699,9 +1699,9 @@ async function retitle(context = github.context) {
     if (issueNumber === undefined) {
         throw new Error(`github context payload missing issue number: ${context.payload}`);
     }
-    const commentArgs = (0, command_1.getCommandArgs)('/retitle', commentBody);
+    const title = (0, command_1.getLineArgs)('/retitle', commentBody);
     // no arguments after command provided. Can't retitle!
-    if (commentArgs.length === 0) {
+    if (title === '') {
         return;
     }
     // Only users who:
@@ -1718,7 +1718,7 @@ async function retitle(context = github.context) {
             await octokit.issues.update({
                 ...context.repo,
                 issue_number: issueNumber,
-                title: commentArgs.join(' '),
+                title,
             });
         }
         catch (e) {
@@ -2002,7 +2002,7 @@ async function hold(context = github.context) {
     }
     const cancel = (0, command_1.hasCommand)('/unhold', commentBody)
         || (0, command_1.hasCommand)('/remove-hold', commentBody)
-        || ((0, command_1.hasCommand)('/hold', commentBody) && (0, command_1.getCommandArgs)('/hold', commentBody)[0] === 'cancel');
+        || ((0, command_1.hasCommand)('/hold', commentBody) && (0, command_1.getCommandArgs)('/hold', commentBody).includes('cancel'));
     if (cancel) {
         try {
             await (0, labeling_1.cancelLabel)(octokit, context, issueNumber, 'hold');
@@ -2099,7 +2099,7 @@ async function lgtm(context = github.context) {
         throw e;
     }
     const cancel = (0, command_1.hasCommand)('/remove-lgtm', commentBody)
-        || ((0, command_1.hasCommand)('/lgtm', commentBody) && (0, command_1.getCommandArgs)('/lgtm', commentBody)[0] === 'cancel');
+        || ((0, command_1.hasCommand)('/lgtm', commentBody) && (0, command_1.getCommandArgs)('/lgtm', commentBody).includes('cancel'));
     if (cancel) {
         try {
             await (0, labeling_1.cancelLabel)(octokit, context, issueNumber, 'lgtm');
@@ -2874,39 +2874,43 @@ exports.getCommandArgs = getCommandArgs;
  * @param body - the full body of the comment
  */
 function hasCommand(command, body) {
-    return findCommandArgs(command, body) !== undefined;
+    return findCommandArgs(command, body).length > 0;
 }
 /**
- * getLineArgs will return the trimmed text following the command on its line
+ * getLineArgs will return the trimmed text following the command on its line.
+ * When the command appears on several lines the last one wins, which suits
+ * single-valued commands such as /milestone and /retitle
  * Ex return: 'some-user some-other-user'
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 function getLineArgs(command, body) {
-    return findCommandArgs(command, body) ?? '';
+    return findCommandArgs(command, body).at(-1) ?? '';
 }
 /**
- * getCommandArgs will return an array of the arguments associated with a command
+ * getCommandArgs will return an array of the arguments associated with a command,
+ * collected in order from every line that carries it and de-duplicated
  * Ex return: [`some-user', 'some-other-user']
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 function getCommandArgs(command, body) {
-    const rest = findCommandArgs(command, body);
-    if (rest === undefined) {
+    const rests = findCommandArgs(command, body);
+    if (rests.length === 0) {
         throw new Error(`command ${command} missing from body`);
     }
-    return stripAtSign(rest.split(/\s+/).filter(Boolean));
+    const args = rests.flatMap(rest => rest.split(/\s+/).filter(Boolean));
+    return [...new Set(stripAtSign(args))];
 }
 function findCommandArgs(command, body) {
     const pattern = commandPattern(command);
-    let found;
+    const found = [];
     for (const line of splitLines(body)) {
         const match = pattern.exec(line);
         if (match) {
-            found = (match[1] ?? '').trim();
+            found.push((match[1] ?? '').trim());
         }
     }
     return found;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2874,7 +2874,7 @@ exports.getCommandArgs = getCommandArgs;
  * @param body - the full body of the comment
  */
 function hasCommand(command, body) {
-    return findCommandLine(command, body) !== undefined;
+    return findCommandArgs(command, body) !== undefined;
 }
 /**
  * getLineArgs will return the trimmed text following the command on its line
@@ -2884,11 +2884,7 @@ function hasCommand(command, body) {
  * @param body - the full body of the comment
  */
 function getLineArgs(command, body) {
-    const line = findCommandLine(command, body);
-    if (line === undefined) {
-        return '';
-    }
-    return line.trim().slice(command.length).trim();
+    return findCommandArgs(command, body) ?? '';
 }
 /**
  * getCommandArgs will return an array of the arguments associated with a command
@@ -2898,19 +2894,19 @@ function getLineArgs(command, body) {
  * @param body - the full body of the comment
  */
 function getCommandArgs(command, body) {
-    const line = findCommandLine(command, body);
-    if (line === undefined) {
+    const rest = findCommandArgs(command, body);
+    if (rest === undefined) {
         throw new Error(`command ${command} missing from body`);
     }
-    const args = line.trim().split(' ').slice(1);
-    return stripAtSign(args);
+    return stripAtSign(rest.split(/\s+/).filter(Boolean));
 }
-function findCommandLine(command, body) {
+function findCommandArgs(command, body) {
     const pattern = commandPattern(command);
     let found;
     for (const line of splitLines(body)) {
-        if (pattern.test(line)) {
-            found = line;
+        const match = pattern.exec(line);
+        if (match) {
+            found = (match[1] ?? '').trim();
         }
     }
     return found;
@@ -2918,7 +2914,8 @@ function findCommandLine(command, body) {
 function commandPattern(command) {
     // escape regex metacharacters so a command is matched literally
     const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`^\\s*${escaped}(\\s|$)`);
+    // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
+    return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`);
 }
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings
 function splitLines(body) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Prow github actions commands
 
-A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command.
+A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command. Listing an alias in `prow-commands` enables the whole command family: configuring only `/remove-kind` also enables `/kind`, and only `/unhold` also enables `/hold`. When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins; a `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
 
 Commands | Policy | Description
 --- | --- | ---

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -62,7 +62,7 @@ export async function approve(
   }
 
   const isCancel = hasCommand('/remove-approve', commentBody)
-    || (hasCommand('/approve', commentBody) && getCommandArgs('/approve', commentBody)[0] === 'cancel')
+    || (hasCommand('/approve', commentBody) && getCommandArgs('/approve', commentBody).includes('cancel'))
 
   if (isCancel) {
     try {

--- a/src/issueComment/retitle.ts
+++ b/src/issueComment/retitle.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import { checkCollaborator } from '../utils/auth'
-import { getCommandArgs } from '../utils/command'
+import { getLineArgs } from '../utils/command'
 import { newOctokit } from '../utils/octokit'
 
 /**
@@ -28,10 +28,10 @@ export async function retitle(
     )
   }
 
-  const commentArgs: string[] = getCommandArgs('/retitle', commentBody)
+  const title: string = getLineArgs('/retitle', commentBody)
 
   // no arguments after command provided. Can't retitle!
-  if (commentArgs.length === 0) {
+  if (title === '') {
     return
   }
 
@@ -50,7 +50,7 @@ export async function retitle(
       await octokit.issues.update({
         ...context.repo,
         issue_number: issueNumber,
-        title: commentArgs.join(' '),
+        title,
       })
     }
     catch (e) {

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -30,7 +30,7 @@ export async function hold(context: Context = github.context): Promise<void> {
 
   const cancel = hasCommand('/unhold', commentBody)
     || hasCommand('/remove-hold', commentBody)
-    || (hasCommand('/hold', commentBody) && getCommandArgs('/hold', commentBody)[0] === 'cancel')
+    || (hasCommand('/hold', commentBody) && getCommandArgs('/hold', commentBody).includes('cancel'))
 
   if (cancel) {
     try {

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -55,7 +55,7 @@ export async function lgtm(context: Context = github.context): Promise<void> {
   }
 
   const cancel = hasCommand('/remove-lgtm', commentBody)
-    || (hasCommand('/lgtm', commentBody) && getCommandArgs('/lgtm', commentBody)[0] === 'cancel')
+    || (hasCommand('/lgtm', commentBody) && getCommandArgs('/lgtm', commentBody).includes('cancel'))
 
   if (cancel) {
     try {

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -7,7 +7,7 @@
  * @param body - the full body of the comment
  */
 export function hasCommand(command: string, body: string): boolean {
-  return findCommandLine(command, body) !== undefined
+  return findCommandArgs(command, body) !== undefined
 }
 
 /**
@@ -18,12 +18,7 @@ export function hasCommand(command: string, body: string): boolean {
  * @param body - the full body of the comment
  */
 export function getLineArgs(command: string, body: string): string {
-  const line = findCommandLine(command, body)
-  if (line === undefined) {
-    return ''
-  }
-
-  return line.trim().slice(command.length).trim()
+  return findCommandArgs(command, body) ?? ''
 }
 
 /**
@@ -34,24 +29,23 @@ export function getLineArgs(command: string, body: string): string {
  * @param body - the full body of the comment
  */
 export function getCommandArgs(command: string, body: string): string[] {
-  const line = findCommandLine(command, body)
+  const rest = findCommandArgs(command, body)
 
-  if (line === undefined) {
+  if (rest === undefined) {
     throw new Error(`command ${command} missing from body`)
   }
 
-  const args = line.trim().split(' ').slice(1)
-
-  return stripAtSign(args)
+  return stripAtSign(rest.split(/\s+/).filter(Boolean))
 }
 
-function findCommandLine(command: string, body: string): string | undefined {
+function findCommandArgs(command: string, body: string): string | undefined {
   const pattern = commandPattern(command)
   let found: string | undefined
 
   for (const line of splitLines(body)) {
-    if (pattern.test(line)) {
-      found = line
+    const match = pattern.exec(line)
+    if (match) {
+      found = (match[1] ?? '').trim()
     }
   }
 
@@ -61,7 +55,8 @@ function findCommandLine(command: string, body: string): string | undefined {
 function commandPattern(command: string): RegExp {
   // escape regex metacharacters so a command is matched literally
   const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`^\\s*${escaped}(\\s|$)`)
+  // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
+  return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`)
 }
 
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -7,45 +7,50 @@
  * @param body - the full body of the comment
  */
 export function hasCommand(command: string, body: string): boolean {
-  return findCommandArgs(command, body) !== undefined
+  return findCommandArgs(command, body).length > 0
 }
 
 /**
- * getLineArgs will return the trimmed text following the command on its line
+ * getLineArgs will return the trimmed text following the command on its line.
+ * When the command appears on several lines the last one wins, which suits
+ * single-valued commands such as /milestone and /retitle
  * Ex return: 'some-user some-other-user'
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 export function getLineArgs(command: string, body: string): string {
-  return findCommandArgs(command, body) ?? ''
+  return findCommandArgs(command, body).at(-1) ?? ''
 }
 
 /**
- * getCommandArgs will return an array of the arguments associated with a command
+ * getCommandArgs will return an array of the arguments associated with a command,
+ * collected in order from every line that carries it and de-duplicated
  * Ex return: [`some-user', 'some-other-user']
  *
  * @param command - the given command to get arguments for. Ex: '/assign'
  * @param body - the full body of the comment
  */
 export function getCommandArgs(command: string, body: string): string[] {
-  const rest = findCommandArgs(command, body)
+  const rests = findCommandArgs(command, body)
 
-  if (rest === undefined) {
+  if (rests.length === 0) {
     throw new Error(`command ${command} missing from body`)
   }
 
-  return stripAtSign(rest.split(/\s+/).filter(Boolean))
+  const args = rests.flatMap(rest => rest.split(/\s+/).filter(Boolean))
+
+  return [...new Set(stripAtSign(args))]
 }
 
-function findCommandArgs(command: string, body: string): string | undefined {
+function findCommandArgs(command: string, body: string): string[] {
   const pattern = commandPattern(command)
-  let found: string | undefined
+  const found: string[] = []
 
   for (const line of splitLines(body)) {
     const match = pattern.exec(line)
     if (match) {
-      found = (match[1] ?? '').trim()
+      found.push((match[1] ?? '').trim())
     }
   }
 


### PR DESCRIPTION
# Description

Post-merge audit of #132 and #133. Line coverage was high, but probing the built code with adversarial input found two real defects and several unpinned behaviours. **254 → 294 tests.**

## `fix(command): derive arguments from the anchored match` — bug
`hasCommand` matched any `\s` after the command, but `getCommandArgs` tokenized with `split(' ')` and re-scanned for the exact command token. So `/kind<TAB>bug` matched and then failed with "kind: command args missing from body"; `/kind  bug` produced an empty argument; `/kind<nbsp>bug` yielded nothing. Arguments are now captured by the same regex (`^\s*<cmd>(?:\s+(.*))?\s*$`) and split on `\s+`. Failing-test-first.

## `feat(command): apply every matching command line, not just the last` — Prow divergence (separate commit; drop it in review if you disagree)
`/kind bug` + `/kind cleanup` on two lines applied only `cleanup`; same for `/assign`, `/cc`, `/remove`. Prow applies every line. `getCommandArgs` now concatenates all matching lines (ordered, de-duplicated); cancel detection in lgtm/hold/approve uses `includes('cancel')` so `/lgtm` + `/lgtm cancel` in either order cancels (Prow: cancel wins). `getLineArgs` stays last-wins for single-valued commands — and **`/retitle` is moved onto it**, because with de-duplication `/retitle fix the bug in the parser` would have become `fix the bug in parser`. Pinned by tests.

## `test: pin alias, milestone, approve and label edge cases`
- **Design decision surfaced, not changed:** listing only `/remove-kind` (or `/unhold`, `/remove-lgtm`) in `prow-commands` enables the whole family, including add. Auth is identical for add/remove so it isn't a privilege issue, but it's surprising. Pinned by tests and stated in `docs/commands.md` + `action.yml`; flip it if you prefer the narrow reading — the tests to invert are marked.
- New scenarios: `/milestone clear` with no milestone set (idempotent PATCH); `/approve no-issue` via OWNERS; `/remove-approve` with no bot review; `/label` with a slash in the name; `/priority high low` + `/remove-priority high` exact DELETE/POST sequence; `/kind` when label already present; `/remove-kind` with two kind labels → exactly one `%2F`-encoded DELETE; alias-only comment for an unconfigured command → no calls; `/label` vs `/labels`, `/kind` vs `/kind/foo` negatives.
- A test **documenting** that a command inside a fenced code block still matches, marked `// #66`, so fixing #66 flips it deliberately.
- Bundle harness: `/milestone clear` scenario against the committed `dist/index.js`.

## Not changed (maintainer calls, noted for the record)
- Case sensitivity: Prow's regexes are mostly `(?mi)`; we ignore `/LGTM`. Easy to add now that matcher and tokenizer share one regex.
- Fenced code blocks (#66) — still matched.

# Testing
- [x] `npm run all` green: 30 files, 294 tests; coverage 89.2 / 90.2 br / 97.1 fn
- [x] Only one pre-existing assertion changed: `command.test.ts` "uses the last matching line" → "collects arguments from every matching line" (the intended F2 change)
- [x] Hermetic under a simulated Actions env; `dist/` byte-identical across repeated packs
