### PR TITLE
feat: Prow parity — case-insensitive commands, self-LGTM guard, author close/reopen/cancel, /close not-planned

### DIFF
--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -16,9 +16,10 @@ vi.setConfig({ testTimeout: 30_000 })
 const repo = '/repos/Codertocat/Hello-World'
 const token = { 'github-token': 'some-token' }
 
-function comment(body: string) {
+function comment(body: string, author = issueCommentEvent.issue.user.login) {
   const payload = structuredClone(issueCommentEvent)
   payload.comment.body = body
+  payload.issue.user.login = author
   return payload
 }
 
@@ -144,12 +145,12 @@ describe('dist/index.js', () => {
     expect(gh.requestsMatching('POST', /assignees$/)[0].body).toEqual({ assignees: ['Codertocat'] })
   })
 
-  it('issue_comment /close by a non-collaborator is a silent no-op', async () => {
+  it('issue_comment /close by a non-collaborator non-author is a silent no-op', async () => {
     gh.route('GET', `${repo}/collaborators/Codertocat`, { status: 404, body: { message: 'Not Found' } })
 
     const result = await runBundle({
       eventName: 'issue_comment',
-      payload: comment('/close'),
+      payload: comment('/close', 'some-author'),
       inputs: { ...token, 'prow-commands': '/close' },
       apiUrl: gh.url,
     })
@@ -159,6 +160,28 @@ describe('dist/index.js', () => {
     expect(gh.requestsMatching('PATCH', /./)).toEqual([])
     expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
       `GET ${repo}/collaborators/Codertocat`,
+    ])
+  })
+
+  it('issue_comment /close not-planned by a collaborator closes with state_reason not_planned', async () => {
+    gh.route('GET', `${repo}/collaborators/Codertocat`, { status: 204 })
+    gh.route('PATCH', `${repo}/issues/1`, { status: 200, body: {} })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/close not-planned', 'some-author'),
+      inputs: { ...token, 'prow-commands': '/close' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    const patches = gh.requestsMatching('PATCH', /\/issues\/1$/)
+    expect(patches).toHaveLength(1)
+    expect(patches[0].body).toEqual({ state: 'closed', state_reason: 'not_planned' })
+    expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      `GET ${repo}/collaborators/Codertocat`,
+      `PATCH ${repo}/issues/1`,
     ])
   })
 

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -162,6 +162,28 @@ describe('dist/index.js', () => {
     ])
   })
 
+  it('issue_comment /lgtm by the pr author is refused with a comment and fails the action', async () => {
+    gh.route('GET', `${repo}/contents/OWNERS`, { status: 404, body: { message: 'Not Found' } })
+    gh.route('GET', '/orgs/Codertocat/members/Codertocat', { status: 204 })
+    gh.route('GET', `${repo}/collaborators/Codertocat`, { status: 204 })
+    gh.route('POST', `${repo}/issues/1/comments`, { status: 201, body: {} })
+    gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/lgtm'),
+      inputs: { ...token, 'prow-commands': '/lgtm' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(1)
+    expect(result.errors.some(e => e.includes('you cannot LGTM your own PR.'))).toBe(true)
+    expect(gh.requestsMatching('POST', /\/issues\/1\/labels$/)).toEqual([])
+    const comments = gh.requestsMatching('POST', /\/issues\/1\/comments$/)
+    expect(comments).toHaveLength(1)
+    expect(comments[0].body).toEqual({ body: 'you cannot LGTM your own PR.' })
+  })
+
   it('issue_comment /remove fails the action when the api returns 500', async () => {
     gh.route('GET', `${repo}/collaborators/Codertocat`, { status: 204 })
     gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'foo' }] } })

--- a/__tests__/issueCommentTest/approve.test.ts
+++ b/__tests__/issueCommentTest/approve.test.ts
@@ -534,7 +534,7 @@ reviewers:
     expect(setFailed).not.toHaveBeenCalled()
   })
 
-  it('removes approval with the /approve cancel command if commenter is collaborator', async () => {
+  it.each(['/approve cancel', '/Approve CANCEL'])('removes approval with %s if commenter is collaborator', async (body) => {
     server.use(
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
@@ -562,7 +562,7 @@ reviewers:
       ),
     )
 
-    issueCommentEventAssign.comment.body = '/approve cancel'
+    issueCommentEventAssign.comment.body = body
     issueCommentEventAssign.comment.user.login = 'some-user'
     const commentContext = new utils.MockContext(issueCommentEventAssign)
 

--- a/__tests__/issueCommentTest/close.test.ts
+++ b/__tests__/issueCommentTest/close.test.ts
@@ -21,6 +21,8 @@ afterAll(() => server.close())
 describe('/close', () => {
   beforeEach(() => {
     utils.setupActionsEnv('/close')
+    // the fixture's issue author and commenter are both Codertocat; authors may /close
+    issueCommentEvent.issue.user.login = 'some-author'
   })
 
   it('closes the issue with /close', async () => {
@@ -45,13 +47,96 @@ describe('/close', () => {
 
     await handleIssueComment(commentContext)
     await observeReq.called()
-    expect(await observeReq.body()).toMatchObject({
+    expect(await observeReq.body()).toEqual({
       state: 'closed',
     })
   })
 
-  it('does not close the issue when commenter is not a collaborator', async () => {
+  it('does not close the issue when commenter is neither a collaborator nor the author', async () => {
     issueCommentEvent.comment.body = '/close'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('lets the author close without checking collaborator status', async () => {
+    issueCommentEvent.comment.body = '/close'
+    issueCommentEvent.issue.user.login = issueCommentEvent.comment.user.login
+
+    const observeAuth = new utils.ObserveRequest()
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404, null, observeAuth),
+      ),
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({ state: 'closed' })
+    await expect(observeAuth.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it.each(['/close not-planned', '/close NOT-PLANNED', '/CLOSE Not-Planned'])('closes as not planned with %s', async (body) => {
+    issueCommentEvent.comment.body = body
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({
+      state: 'closed',
+      state_reason: 'not_planned',
+    })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('does not close as not planned when commenter is neither a collaborator nor the author', async () => {
+    issueCommentEvent.comment.body = '/close not-planned'
 
     server.use(
       http.get(

--- a/__tests__/issueCommentTest/handleIssueComment.test.ts
+++ b/__tests__/issueCommentTest/handleIssueComment.test.ts
@@ -336,3 +336,46 @@ it.each(['/area', '/kind', '/priority', '/label'])('ignores a lone /remove-%s al
   expect(remove).not.toHaveBeenCalled()
   expect(setFailed).not.toHaveBeenCalled()
 })
+
+it('dispatches an upper-case command in the comment body', async () => {
+  utils.setupActionsEnv('/lgtm')
+
+  vi.spyOn(lgtm, 'lgtm').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/LGTM'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(lgtm.lgtm).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('accepts a mixed-case entry in prow-commands and dispatches its lower-case command', async () => {
+  utils.setupActionsEnv('/Kind')
+
+  const add = vi.spyOn(prefixed, 'addPrefixedLabels').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/kind cleanup'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(add).toHaveBeenCalledTimes(1)
+  expect(add.mock.calls[0][1]).toMatchObject({ command: '/kind' })
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('resolves an upper-case alias in prow-commands to its base command', async () => {
+  utils.setupActionsEnv('/UNHOLD')
+
+  vi.spyOn(hold, 'hold').mockImplementation(() => Promise.resolve())
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+  issueCommentEvent.comment.body = '/hold'
+  const context = new utils.MockContext(issueCommentEvent)
+
+  await handleIssueComment(context)
+  expect(hold.hold).toHaveBeenCalledTimes(1)
+  expect(setFailed).not.toHaveBeenCalled()
+})

--- a/__tests__/issueCommentTest/milestone.test.ts
+++ b/__tests__/issueCommentTest/milestone.test.ts
@@ -114,6 +114,38 @@ describe('/milestone', () => {
     )
   })
 
+  it('matches milestone titles case-sensitively even though the command is not', async () => {
+    issueCommentEvent.comment.body = '/MILESTONE Some Milestone'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/milestones`,
+        utils.mockResponse(200, repoMilestones),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('milestone "Some Milestone" not found'),
+    )
+  })
+
   it('reports none when the repository has no milestones', async () => {
     issueCommentEvent.comment.body = '/milestone v9'
 
@@ -137,8 +169,8 @@ describe('/milestone', () => {
     )
   })
 
-  it('clears the milestone with /milestone clear', async () => {
-    issueCommentEvent.comment.body = '/milestone clear'
+  it.each(['/milestone clear', '/Milestone CLEAR'])('clears the milestone with %s', async (body) => {
+    issueCommentEvent.comment.body = body
 
     server.use(
       http.get(

--- a/__tests__/issueCommentTest/reopen.test.ts
+++ b/__tests__/issueCommentTest/reopen.test.ts
@@ -21,6 +21,8 @@ afterAll(() => server.close())
 describe('/reopen', () => {
   beforeEach(() => {
     utils.setupActionsEnv('/reopen')
+    // the fixture's issue author and commenter are both Codertocat; authors may /reopen
+    issueCommentEvent.issue.user.login = 'some-author'
   })
 
   it('reopens the issue with /reopen', async () => {
@@ -45,12 +47,12 @@ describe('/reopen', () => {
 
     await handleIssueComment(commentContext)
     await observeReq.called()
-    expect(await observeReq.body()).toMatchObject({
+    expect(await observeReq.body()).toEqual({
       state: 'open',
     })
   })
 
-  it('does not reopen the issue when commenter is not a collaborator', async () => {
+  it('does not reopen the issue when commenter is neither a collaborator nor the author', async () => {
     issueCommentEvent.comment.body = '/reopen'
 
     server.use(
@@ -73,6 +75,33 @@ describe('/reopen', () => {
     const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
     await handleIssueComment(commentContext)
     await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('lets the author reopen without checking collaborator status', async () => {
+    issueCommentEvent.comment.body = '/reopen'
+    issueCommentEvent.issue.user.login = issueCommentEvent.comment.user.login
+
+    const observeAuth = new utils.ObserveRequest()
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404, null, observeAuth),
+      ),
+      http.patch(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toEqual({ state: 'open' })
+    await expect(observeAuth.notCalled()).resolves.toBe('not called')
     expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -42,6 +42,25 @@ describe('hold', () => {
     })
   })
 
+  it('labels the issue with /HOLD', async () => {
+    issueCommentEvent.comment.body = '/HOLD'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toMatchObject({
+      labels: ['hold'],
+    })
+  })
+
   it('removes the hold label with /hold cancel', async () => {
     issueCommentEvent.comment.body = '/hold cancel'
     const commentContext = new utils.MockContext(issueCommentEvent)
@@ -131,7 +150,7 @@ describe('hold', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
-  it.each(['/unhold', '/remove-hold'])('removes the hold label with %s', async (body) => {
+  it.each(['/unhold', '/remove-hold', '/UNHOLD', '/Hold Cancel'])('removes the hold label with %s', async (body) => {
     issueCommentEvent.comment.body = body
     const commentContext = new utils.MockContext(issueCommentEvent)
 

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -25,6 +25,8 @@ afterAll(() => server.close())
 describe('lgtm', () => {
   beforeEach(() => {
     utils.setupActionsEnv('/lgtm')
+    // the fixture's issue author and commenter are both Codertocat; an author cannot /lgtm
+    issueCommentEvent.issue.user.login = 'some-author'
   })
 
   it('labels the issue with the lgtm label', async () => {
@@ -536,5 +538,163 @@ reviewers:
     await expect(observeDelete.called()).resolves.toBe('called')
     await expect(observeAdd.notCalled()).resolves.toBe('not called')
     expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  describe('by the author', () => {
+    beforeEach(() => {
+      issueCommentEvent.issue.user.login = issueCommentEvent.comment.user.login
+    })
+
+    it('refuses /lgtm on their own PR even when they are a reviewer', async () => {
+      issueCommentEvent.comment.body = '/lgtm'
+      const commentContext = new utils.MockContext(issueCommentEvent)
+
+      const wantErr = 'you cannot LGTM your own PR.'
+
+      const observeAdd = new utils.ObserveRequest()
+      const observeComment = new utils.ObserveRequest()
+      server.use(
+        http.post(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+          utils.mockResponse(200, null, observeAdd),
+        ),
+        http.post(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+          utils.mockResponse(200, null, observeComment),
+        ),
+        http.get(
+          `${utils.api}/orgs/Codertocat/members/Codertocat`,
+          utils.mockResponse(204),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+          utils.mockResponse(204),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+          utils.mockResponse(404),
+        ),
+      )
+
+      const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+      await handleIssueComment(commentContext)
+      await observeComment.called()
+      expect(await observeComment.body().then(body => body.body)).toBe(wantErr)
+      await expect(observeAdd.notCalled()).resolves.toBe('not called')
+      expect(setFailed).toHaveBeenCalledWith(expect.stringContaining(wantErr))
+    })
+
+    it('lets them /lgtm cancel without reviewer authorization', async () => {
+      issueCommentEvent.comment.body = '/lgtm cancel'
+      const commentContext = new utils.MockContext(issueCommentEvent)
+
+      const payload = structuredClone(issuePayload)
+      payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+
+      const observeDelete = new utils.ObserveRequest()
+      const observeComment = new utils.ObserveRequest()
+      server.use(
+        http.delete(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+          utils.mockResponse(200, null, observeDelete),
+        ),
+        http.post(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+          utils.mockResponse(200, null, observeComment),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+          utils.mockResponse(200, payload),
+        ),
+        http.get(
+          `${utils.api}/orgs/Codertocat/members/Codertocat`,
+          utils.mockResponse(404),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+          utils.mockResponse(404),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+          utils.mockResponse(404),
+        ),
+      )
+
+      const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+      await handleIssueComment(commentContext)
+      await expect(observeDelete.called()).resolves.toBe('called')
+      await expect(observeComment.notCalled()).resolves.toBe('not called')
+      expect(setFailed).not.toHaveBeenCalled()
+    })
+
+    it('lets them /remove-lgtm without reviewer authorization', async () => {
+      issueCommentEvent.comment.body = '/remove-lgtm'
+      const commentContext = new utils.MockContext(issueCommentEvent)
+
+      const payload = structuredClone(issuePayload)
+      payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+
+      const observeDelete = new utils.ObserveRequest()
+      const observeAuth = new utils.ObserveRequest()
+      server.use(
+        http.delete(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+          utils.mockResponse(200, null, observeDelete),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+          utils.mockResponse(200, payload),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+          utils.mockResponse(404, null, observeAuth),
+        ),
+      )
+
+      const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+      await handleIssueComment(commentContext)
+      await expect(observeDelete.called()).resolves.toBe('called')
+      await expect(observeAuth.notCalled()).resolves.toBe('not called')
+      expect(setFailed).not.toHaveBeenCalled()
+    })
+  })
+
+  it('still rejects /lgtm cancel from a non-author who is not a reviewer', async () => {
+    issueCommentEvent.comment.body = '/lgtm cancel'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const wantErr = `Codertocat is not a org member or collaborator`
+
+    const observeDelete = new utils.ObserveRequest()
+    const observeComment = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
+        utils.mockResponse(200, null, observeComment),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeComment.called()
+    expect(await observeComment.body().then(body => body.body)).toContain(wantErr)
+    await expect(observeDelete.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining(wantErr))
   })
 })

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -463,4 +463,78 @@ reviewers:
       expect.stringContaining('not a org member or collaborator'),
     )
   })
+
+  it('labels the issue with /LGTM', async () => {
+    issueCommentEvent.comment.body = '/LGTM'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toMatchObject({ labels: ['lgtm'] })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('removes the lgtm label with /Lgtm CANCEL', async () => {
+    issueCommentEvent.comment.body = '/Lgtm CANCEL'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+
+    const observeDelete = new utils.ObserveRequest()
+    const observeAdd = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observeAdd),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
+      ),
+      http.get(
+        `${utils.api}/orgs/Codertocat/members/Codertocat`,
+        utils.mockResponse(204),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(404),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/OWNERS`,
+        utils.mockResponse(404),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDelete.called()).resolves.toBe('called')
+    await expect(observeAdd.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/utils/command.test.ts
+++ b/__tests__/utils/command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getCommandArgs, getLineArgs, hasCommand } from '../../src/utils/command'
+import { getCommandArgs, getLineArgs, hasCommand, hasKeyword } from '../../src/utils/command'
 
 it('handles comments with multiple lines', () => {
   const body = `Here is something
@@ -199,5 +199,41 @@ describe('getLineArgs', () => {
   it('returns an empty string when the command is absent', () => {
     expect(getLineArgs('/milestone', 'no command here')).toBe('')
     expect(getLineArgs('/milestone', 'set /milestone v1.2 please')).toBe('')
+  })
+})
+
+describe('case-insensitive matching', () => {
+  it('matches a command regardless of case', () => {
+    expect(hasCommand('/lgtm', '/LGTM')).toBe(true)
+    expect(hasCommand('/lgtm', '/Lgtm cancel')).toBe(true)
+    expect(hasCommand('/remove-lgtm', '/Remove-LGTM')).toBe(true)
+    expect(hasCommand('/lgtm', '/lgtmx')).toBe(false)
+    expect(hasCommand('/lgtm', '/LGTMX')).toBe(false)
+  })
+
+  it('keeps the case of the arguments', () => {
+    expect(getCommandArgs('/lgtm', '/Lgtm Cancel')).toEqual(['Cancel'])
+    expect(getCommandArgs('/kind', '/KIND Bug')).toEqual(['Bug'])
+    expect(getLineArgs('/milestone', '/MILESTONE V1.0')).toBe('V1.0')
+  })
+
+  it('still refuses a longer command sharing the prefix', () => {
+    expect(hasCommand('/lgtm', '/REMOVE-LGTM')).toBe(false)
+    expect(() => getCommandArgs('/lgtm', '/REMOVE-LGTM')).toThrow('command /lgtm missing from body')
+  })
+})
+
+describe('hasKeyword', () => {
+  it('matches a keyword regardless of case', () => {
+    expect(hasKeyword(['cancel'], 'cancel')).toBe(true)
+    expect(hasKeyword(['Cancel'], 'cancel')).toBe(true)
+    expect(hasKeyword(['CANCEL'], 'cancel')).toBe(true)
+    expect(hasKeyword(['foo', 'NOT-PLANNED'], 'not-planned')).toBe(true)
+  })
+
+  it('requires a whole-argument match', () => {
+    expect(hasKeyword([], 'cancel')).toBe(false)
+    expect(hasKeyword(['cancelled'], 'cancel')).toBe(false)
+    expect(hasKeyword(['no-cancel'], 'cancel')).toBe(false)
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -44134,6 +44134,7 @@ async function createComment(octokit, context, issueNum, message) {
 /**
  * /lgtm will add the lgtm label.
  * /lgtm cancel and /remove-lgtm remove it.
+ * Like Prow, the author cannot lgtm their own PR but may cancel an lgtm on it.
  * Note - this label is used to indicate automatic merging
  * if the user has configured a cron job to perform automatic merging
  *
@@ -44145,28 +44146,16 @@ async function lgtm(context = github_context) {
     const issueNumber = context.payload.issue?.number;
     const commentBody = context.payload.comment?.body;
     const commenterId = context.payload.comment?.user?.login;
+    const isAuthor = commenterId === context.payload.issue?.user?.login;
     if (issueNumber === undefined) {
         throw new Error(`github context payload missing issue number: ${context.payload}`);
-    }
-    try {
-        await assertAuthorizedByOwnersOrMembership(octokit, context, 'reviewers', commenterId);
-    }
-    catch (e) {
-        const msg = `Cannot apply the lgtm label because ${e}`;
-        error(msg);
-        // Try to reply back that the user is unauthorized
-        try {
-            await createComment(octokit, context, issueNumber, msg);
-        }
-        catch (commentE) {
-            // Log the comment error but continue to throw the original auth error
-            error(`Could not comment with an auth error: ${commentE}`);
-        }
-        throw e;
     }
     const cancel = hasCommand('/remove-lgtm', commentBody)
         || (hasCommand('/lgtm', commentBody) && hasKeyword(getCommandArgs('/lgtm', commentBody), 'cancel'));
     if (cancel) {
+        if (!isAuthor) {
+            await assertReviewer(octokit, context, issueNumber, commenterId);
+        }
         try {
             await cancelLabel(octokit, context, issueNumber, 'lgtm');
         }
@@ -44175,7 +44164,30 @@ async function lgtm(context = github_context) {
         }
         return;
     }
+    if (isAuthor) {
+        await refuse(octokit, context, issueNumber, 'you cannot LGTM your own PR.');
+    }
+    await assertReviewer(octokit, context, issueNumber, commenterId);
     await labelIssue(octokit, context, issueNumber, ['lgtm']);
+}
+async function assertReviewer(octokit, context, issueNumber, commenterId) {
+    try {
+        await assertAuthorizedByOwnersOrMembership(octokit, context, 'reviewers', commenterId);
+    }
+    catch (e) {
+        await refuse(octokit, context, issueNumber, `Cannot apply the lgtm label because ${e}`, e);
+    }
+}
+// refuse logs and replies with msg, then fails the run with cause (or msg)
+async function refuse(octokit, context, issueNumber, msg, cause = new Error(msg)) {
+    error(msg);
+    try {
+        await createComment(octokit, context, issueNumber, msg);
+    }
+    catch (commentE) {
+        error(`Could not comment with an auth error: ${commentE}`);
+    }
+    throw cause;
 }
 
 ;// CONCATENATED MODULE: ./lib/labels/prefixed.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -44622,8 +44622,10 @@ async function selfReview(octokit, context, pullNum, user) {
 
 
 
+
 /**
- * /close will close the issue / PR
+ * /close will close the issue / PR.
+ * /close not-planned closes it with the not_planned state reason
  *
  * @param context - the github actions event context
  */
@@ -44631,26 +44633,42 @@ async function close_close(context = github_context) {
     const token = getInput('github-token', { required: true });
     const octokit = newOctokit(token);
     const issueNumber = context.payload.issue?.number;
+    const commentBody = context.payload.comment?.body;
     const commenterId = context.payload.comment?.user?.login;
     if (issueNumber === undefined) {
         throw new Error(`github context payload missing issue number: ${context.payload}`);
     }
     // Only users who:
+    // - are the issue / PR author
     // - are collaborators
-    let isAuthUser = false;
-    try {
-        isAuthUser = await checkCollaborator(octokit, context, commenterId);
-    }
-    catch (e) {
-        throw new Error(`could not check commentor auth: ${e}`);
+    const isAuthor = commenterId === context.payload.issue?.user?.login;
+    let isAuthUser = isAuthor;
+    if (!isAuthor) {
+        try {
+            isAuthUser = await checkCollaborator(octokit, context, commenterId);
+        }
+        catch (e) {
+            throw new Error(`could not check commentor auth: ${e}`);
+        }
     }
     if (isAuthUser) {
+        const notPlanned = hasKeyword(getCommandArgs('/close', commentBody), 'not-planned');
         try {
-            await octokit.issues.update({
-                ...context.repo,
-                issue_number: issueNumber,
-                state: 'closed',
-            });
+            if (notPlanned) {
+                await octokit.issues.update({
+                    ...context.repo,
+                    issue_number: issueNumber,
+                    state: 'closed',
+                    state_reason: 'not_planned',
+                });
+            }
+            else {
+                await octokit.issues.update({
+                    ...context.repo,
+                    issue_number: issueNumber,
+                    state: 'closed',
+                });
+            }
         }
         catch (e) {
             throw new Error(`could not close issue: ${e}`);
@@ -44981,13 +44999,17 @@ async function reopen(context = github_context) {
         throw new Error(`github context payload missing issue number: ${context.payload}`);
     }
     // Only users who:
+    // - are the issue / PR author
     // - are collaborators
-    let isAuthUser = false;
-    try {
-        isAuthUser = await checkCollaborator(octokit, context, commenterId);
-    }
-    catch (e) {
-        throw new Error(`could not check commentor auth: ${e}`);
+    const isAuthor = commenterId === context.payload.issue?.user?.login;
+    let isAuthUser = isAuthor;
+    if (!isAuthor) {
+        try {
+            isAuthUser = await checkCollaborator(octokit, context, commenterId);
+        }
+        catch (e) {
+            throw new Error(`could not check commentor auth: ${e}`);
+        }
     }
     if (isAuthUser) {
         try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -43617,6 +43617,16 @@ function getCommandArgs(command, body) {
     const args = rests.flatMap(rest => rest.split(/\s+/).filter(Boolean));
     return [...new Set(stripAtSign(args))];
 }
+/**
+ * hasKeyword reports whether a command keyword such as 'cancel' or 'clear'
+ * is among the arguments, ignoring case like Prow's (?i) plugin regexes
+ *
+ * @param args - the arguments returned by getCommandArgs
+ * @param keyword - the lowercase keyword to look for
+ */
+function hasKeyword(args, keyword) {
+    return args.some(arg => arg.toLowerCase() === keyword);
+}
 function findCommandArgs(command, body) {
     const pattern = commandPattern(command);
     const found = [];
@@ -43632,7 +43642,7 @@ function commandPattern(command) {
     // escape regex metacharacters so a command is matched literally
     const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
-    return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`);
+    return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`, 'i');
 }
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings
 function splitLines(body) {
@@ -43850,7 +43860,7 @@ async function hold(context = github_context) {
     }
     const cancel = hasCommand('/unhold', commentBody)
         || hasCommand('/remove-hold', commentBody)
-        || (hasCommand('/hold', commentBody) && getCommandArgs('/hold', commentBody).includes('cancel'));
+        || (hasCommand('/hold', commentBody) && hasKeyword(getCommandArgs('/hold', commentBody), 'cancel'));
     if (cancel) {
         try {
             await cancelLabel(octokit, context, issueNumber, 'hold');
@@ -44155,7 +44165,7 @@ async function lgtm(context = github_context) {
         throw e;
     }
     const cancel = hasCommand('/remove-lgtm', commentBody)
-        || (hasCommand('/lgtm', commentBody) && getCommandArgs('/lgtm', commentBody).includes('cancel'));
+        || (hasCommand('/lgtm', commentBody) && hasKeyword(getCommandArgs('/lgtm', commentBody), 'cancel'));
     if (cancel) {
         try {
             await cancelLabel(octokit, context, issueNumber, 'lgtm');
@@ -44370,7 +44380,7 @@ async function approve(context = github_context) {
         throw e;
     }
     const isCancel = hasCommand('/remove-approve', commentBody)
-        || (hasCommand('/approve', commentBody) && getCommandArgs('/approve', commentBody).includes('cancel'));
+        || (hasCommand('/approve', commentBody) && hasKeyword(getCommandArgs('/approve', commentBody), 'cancel'));
     if (isCancel) {
         try {
             await cancel(octokit, context, issueNumber, commenterLogin);
@@ -44916,7 +44926,7 @@ async function milestone(context = github_context) {
     if (milestoneToAdd === '') {
         throw new Error(`please provide a milestone to add`);
     }
-    if (milestoneToAdd === 'clear') {
+    if (milestoneToAdd.toLowerCase() === 'clear') {
         await octokit.issues.update({
             ...context.repo,
             issue_number: issueNumber,
@@ -45203,7 +45213,7 @@ async function handleIssueComment(context = github_context) {
     const commandConfig = [...new Set(getInput('prow-commands', { required: false })
             .split(/\s+/)
             .filter(command => command !== '')
-            .map(canonicalCommand))];
+            .map(command => canonicalCommand(command.toLowerCase())))];
     const commentBody = context.payload.comment?.body;
     if (commandConfig.length === 0) {
         setFailed(`please provide a list of space delimited commands / jobs to run. None found`);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,8 +12,9 @@ Commands | Policy | Description
 `/unassign [@userA @userB @etc]` | anyone | Unassigns specified people (or yourself if no one is specified). Target must have been already assigned.
 `/cc [@userA @userB @etc]` | anyone | Request review from specified people (or yourself if no one is specified). Target be an Org Member, Collaborator, or have previously commented.
 `/uncc [@userA @userB @etc]` | anyone | Dismiss review request for specified people (or yourself if no one is specified). Target must already have had a review requested.
-`/close` | Collaborators | closes the issue / PR
-`/reopen` | Collaborators | reopens a closed issue / PR
+`/close` | Collaborators **or the issue/PR author** | closes the issue / PR
+`/close not-planned` | Collaborators **or the issue/PR author** | closes the issue / PR with the `not planned` state reason
+`/reopen` | Collaborators **or the issue/PR author** | reopens a closed issue / PR
 `/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason
 `/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone. An unknown title fails the run with the list of available milestones
 `/milestone clear` | Collaborators | Removes the issue / PR from its milestone

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Prow github actions commands
 
-A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command. Listing an alias in `prow-commands` enables the whole command family: configuring only `/remove-kind` also enables `/kind`, and only `/unhold` also enables `/hold`. When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins; a `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
+A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Commands and their keywords are case-insensitive (`/LGTM cancel` works); label values are matched by the label configuration, and milestone titles are matched exactly. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command. Listing an alias in `prow-commands` enables the whole command family: configuring only `/remove-kind` also enables `/kind`, and only `/unhold` also enables `/hold`. When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins; a `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
 
 Commands | Policy | Description
 --- | --- | ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,9 +26,9 @@ Label Commands | Policy | Description
 `/remove-area [label1 label2 ...]` | anyone | removes an area/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
 `/kind [label1 label2 ...]` | anyone | adds a kind/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
 `/remove-kind [label1 label2 ...]` | anyone | removes a kind/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
-`/lgtm` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | adds the `lgtm` label. This is used for [automatic PR merging](./automatic-merging.md)
-`/lgtm cancel` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | removes the `lgtm` label
-`/remove-lgtm` | [OWNERS](#owners) if present, otherwise Collaborators and Org Members | same as `/lgtm cancel`
+`/lgtm` | [OWNERS](#owners) reviewers if present, otherwise Collaborators and Org Members; **not the PR author** | adds the `lgtm` label. This is used for [automatic PR merging](./automatic-merging.md). Like Prow, you cannot LGTM your own PR; the guard also applies to issues since the label has no meaning there either
+`/lgtm cancel` | [OWNERS](#owners) reviewers if present, otherwise Collaborators and Org Members, **or the PR author** | removes the `lgtm` label
+`/remove-lgtm` | [OWNERS](#owners) reviewers if present, otherwise Collaborators and Org Members, **or the PR author** | same as `/lgtm cancel`
 `/hold` | anyone | adds the `hold` label which prevents [automatic PR merging](./automatic-merging.md). Also see [lgtm removal on pr update](./pr-jobs.md)
 `/hold cancel` | anyone | removes the `hold` label
 `/unhold`, `/remove-hold` | anyone | same as `/hold cancel`

--- a/src/issueComment/approve.ts
+++ b/src/issueComment/approve.ts
@@ -4,7 +4,7 @@ import type { Context } from '../utils/context'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { getCommandArgs, hasCommand } from '../utils/command'
+import { getCommandArgs, hasCommand, hasKeyword } from '../utils/command'
 import { createComment } from '../utils/comments'
 import { newOctokit } from '../utils/octokit'
 
@@ -62,7 +62,7 @@ export async function approve(
   }
 
   const isCancel = hasCommand('/remove-approve', commentBody)
-    || (hasCommand('/approve', commentBody) && getCommandArgs('/approve', commentBody).includes('cancel'))
+    || (hasCommand('/approve', commentBody) && hasKeyword(getCommandArgs('/approve', commentBody), 'cancel'))
 
   if (isCancel) {
     try {

--- a/src/issueComment/close.ts
+++ b/src/issueComment/close.ts
@@ -3,10 +3,12 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import { checkCollaborator } from '../utils/auth'
+import { getCommandArgs, hasKeyword } from '../utils/command'
 import { newOctokit } from '../utils/octokit'
 
 /**
- * /close will close the issue / PR
+ * /close will close the issue / PR.
+ * /close not-planned closes it with the not_planned state reason
  *
  * @param context - the github actions event context
  */
@@ -15,6 +17,7 @@ export async function close(context: Context = github.context): Promise<void> {
   const octokit = newOctokit(token)
 
   const issueNumber: number | undefined = context.payload.issue?.number
+  const commentBody: string = context.payload.comment?.body
   const commenterId: string = context.payload.comment?.user?.login
 
   if (issueNumber === undefined) {
@@ -24,22 +27,38 @@ export async function close(context: Context = github.context): Promise<void> {
   }
 
   // Only users who:
+  // - are the issue / PR author
   // - are collaborators
-  let isAuthUser: boolean = false
-  try {
-    isAuthUser = await checkCollaborator(octokit, context, commenterId)
-  }
-  catch (e) {
-    throw new Error(`could not check commentor auth: ${e}`)
+  const isAuthor = commenterId === context.payload.issue?.user?.login
+  let isAuthUser: boolean = isAuthor
+  if (!isAuthor) {
+    try {
+      isAuthUser = await checkCollaborator(octokit, context, commenterId)
+    }
+    catch (e) {
+      throw new Error(`could not check commentor auth: ${e}`)
+    }
   }
 
   if (isAuthUser) {
+    const notPlanned = hasKeyword(getCommandArgs('/close', commentBody), 'not-planned')
+
     try {
-      await octokit.issues.update({
-        ...context.repo,
-        issue_number: issueNumber,
-        state: 'closed',
-      })
+      if (notPlanned) {
+        await octokit.issues.update({
+          ...context.repo,
+          issue_number: issueNumber,
+          state: 'closed',
+          state_reason: 'not_planned',
+        })
+      }
+      else {
+        await octokit.issues.update({
+          ...context.repo,
+          issue_number: issueNumber,
+          state: 'closed',
+        })
+      }
     }
     catch (e) {
       throw new Error(`could not close issue: ${e}`)

--- a/src/issueComment/handleIssueComment.ts
+++ b/src/issueComment/handleIssueComment.ts
@@ -57,7 +57,7 @@ export async function handleIssueComment(context: Context = github.context): Pro
       .getInput('prow-commands', { required: false })
       .split(/\s+/)
       .filter(command => command !== '')
-      .map(canonicalCommand),
+      .map(command => canonicalCommand(command.toLowerCase())),
   )]
   const commentBody: string = context.payload.comment?.body
 

--- a/src/issueComment/milestone.ts
+++ b/src/issueComment/milestone.ts
@@ -52,7 +52,7 @@ export async function milestone(
     throw new Error(`please provide a milestone to add`)
   }
 
-  if (milestoneToAdd === 'clear') {
+  if (milestoneToAdd.toLowerCase() === 'clear') {
     await octokit.issues.update({
       ...context.repo,
       issue_number: issueNumber,

--- a/src/issueComment/reopen.ts
+++ b/src/issueComment/reopen.ts
@@ -24,13 +24,17 @@ export async function reopen(context: Context = github.context): Promise<void> {
   }
 
   // Only users who:
+  // - are the issue / PR author
   // - are collaborators
-  let isAuthUser: boolean = false
-  try {
-    isAuthUser = await checkCollaborator(octokit, context, commenterId)
-  }
-  catch (e) {
-    throw new Error(`could not check commentor auth: ${e}`)
+  const isAuthor = commenterId === context.payload.issue?.user?.login
+  let isAuthUser: boolean = isAuthor
+  if (!isAuthor) {
+    try {
+      isAuthUser = await checkCollaborator(octokit, context, commenterId)
+    }
+    catch (e) {
+      throw new Error(`could not check commentor auth: ${e}`)
+    }
   }
 
   if (isAuthUser) {

--- a/src/labels/hold.ts
+++ b/src/labels/hold.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core'
 
 import * as github from '@actions/github'
 
-import { getCommandArgs, hasCommand } from '../utils/command'
+import { getCommandArgs, hasCommand, hasKeyword } from '../utils/command'
 import { cancelLabel, labelIssue } from '../utils/labeling'
 import { newOctokit } from '../utils/octokit'
 
@@ -30,7 +30,7 @@ export async function hold(context: Context = github.context): Promise<void> {
 
   const cancel = hasCommand('/unhold', commentBody)
     || hasCommand('/remove-hold', commentBody)
-    || (hasCommand('/hold', commentBody) && getCommandArgs('/hold', commentBody).includes('cancel'))
+    || (hasCommand('/hold', commentBody) && hasKeyword(getCommandArgs('/hold', commentBody), 'cancel'))
 
   if (cancel) {
     try {

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -1,3 +1,4 @@
+import type { Octokit } from '@octokit/rest'
 import type { Context } from '../utils/context'
 import * as core from '@actions/core'
 
@@ -12,6 +13,7 @@ import { newOctokit } from '../utils/octokit'
 /**
  * /lgtm will add the lgtm label.
  * /lgtm cancel and /remove-lgtm remove it.
+ * Like Prow, the author cannot lgtm their own PR but may cancel an lgtm on it.
  * Note - this label is used to indicate automatic merging
  * if the user has configured a cron job to perform automatic merging
  *
@@ -24,6 +26,7 @@ export async function lgtm(context: Context = github.context): Promise<void> {
   const issueNumber: number | undefined = context.payload.issue?.number
   const commentBody: string = context.payload.comment?.body
   const commenterId: string = context.payload.comment?.user?.login
+  const isAuthor = commenterId === context.payload.issue?.user?.login
 
   if (issueNumber === undefined) {
     throw new Error(
@@ -31,33 +34,14 @@ export async function lgtm(context: Context = github.context): Promise<void> {
     )
   }
 
-  try {
-    await assertAuthorizedByOwnersOrMembership(
-      octokit,
-      context,
-      'reviewers',
-      commenterId,
-    )
-  }
-  catch (e) {
-    const msg = `Cannot apply the lgtm label because ${e}`
-    core.error(msg)
-
-    // Try to reply back that the user is unauthorized
-    try {
-      await createComment(octokit, context, issueNumber, msg)
-    }
-    catch (commentE) {
-      // Log the comment error but continue to throw the original auth error
-      core.error(`Could not comment with an auth error: ${commentE}`)
-    }
-    throw e
-  }
-
   const cancel = hasCommand('/remove-lgtm', commentBody)
     || (hasCommand('/lgtm', commentBody) && hasKeyword(getCommandArgs('/lgtm', commentBody), 'cancel'))
 
   if (cancel) {
+    if (!isAuthor) {
+      await assertReviewer(octokit, context, issueNumber, commenterId)
+    }
+
     try {
       await cancelLabel(octokit, context, issueNumber, 'lgtm')
     }
@@ -67,5 +51,49 @@ export async function lgtm(context: Context = github.context): Promise<void> {
     return
   }
 
+  if (isAuthor) {
+    await refuse(octokit, context, issueNumber, 'you cannot LGTM your own PR.')
+  }
+
+  await assertReviewer(octokit, context, issueNumber, commenterId)
+
   await labelIssue(octokit, context, issueNumber, ['lgtm'])
+}
+
+async function assertReviewer(
+  octokit: Octokit,
+  context: Context,
+  issueNumber: number,
+  commenterId: string,
+): Promise<void> {
+  try {
+    await assertAuthorizedByOwnersOrMembership(
+      octokit,
+      context,
+      'reviewers',
+      commenterId,
+    )
+  }
+  catch (e) {
+    await refuse(octokit, context, issueNumber, `Cannot apply the lgtm label because ${e}`, e)
+  }
+}
+
+// refuse logs and replies with msg, then fails the run with cause (or msg)
+async function refuse(
+  octokit: Octokit,
+  context: Context,
+  issueNumber: number,
+  msg: string,
+  cause: unknown = new Error(msg),
+): Promise<never> {
+  core.error(msg)
+
+  try {
+    await createComment(octokit, context, issueNumber, msg)
+  }
+  catch (commentE) {
+    core.error(`Could not comment with an auth error: ${commentE}`)
+  }
+  throw cause
 }

--- a/src/labels/lgtm.ts
+++ b/src/labels/lgtm.ts
@@ -4,7 +4,7 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import { assertAuthorizedByOwnersOrMembership } from '../utils/auth'
-import { getCommandArgs, hasCommand } from '../utils/command'
+import { getCommandArgs, hasCommand, hasKeyword } from '../utils/command'
 import { createComment } from '../utils/comments'
 import { cancelLabel, labelIssue } from '../utils/labeling'
 import { newOctokit } from '../utils/octokit'
@@ -55,7 +55,7 @@ export async function lgtm(context: Context = github.context): Promise<void> {
   }
 
   const cancel = hasCommand('/remove-lgtm', commentBody)
-    || (hasCommand('/lgtm', commentBody) && getCommandArgs('/lgtm', commentBody).includes('cancel'))
+    || (hasCommand('/lgtm', commentBody) && hasKeyword(getCommandArgs('/lgtm', commentBody), 'cancel'))
 
   if (cancel) {
     try {

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -43,6 +43,17 @@ export function getCommandArgs(command: string, body: string): string[] {
   return [...new Set(stripAtSign(args))]
 }
 
+/**
+ * hasKeyword reports whether a command keyword such as 'cancel' or 'clear'
+ * is among the arguments, ignoring case like Prow's (?i) plugin regexes
+ *
+ * @param args - the arguments returned by getCommandArgs
+ * @param keyword - the lowercase keyword to look for
+ */
+export function hasKeyword(args: string[], keyword: string): boolean {
+  return args.some(arg => arg.toLowerCase() === keyword)
+}
+
 function findCommandArgs(command: string, body: string): string[] {
   const pattern = commandPattern(command)
   const found: string[] = []
@@ -61,7 +72,7 @@ function commandPattern(command: string): RegExp {
   // escape regex metacharacters so a command is matched literally
   const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
-  return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`)
+  return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`, 'i')
 }
 
 // splitLines splits a comment body into lines, tolerating CRLF and CR endings


### PR DESCRIPTION
# Description

Tier 1 of the Prow parity gap analysis: five small semantic divergences in commands we already have. Closes #91.

| Gap | Prow | Now |
|---|---|---|
| Case | plugin regexes are `(?mi)` | `/LGTM`, `/Lgtm CANCEL`, `/UNHOLD`, `/Milestone CLEAR`, config `/Kind` all work. Args keep their case (label values are the label engine's business); milestone titles stay exact. |
| Self-LGTM | "you cannot LGTM your own PR." | Author `/lgtm` → that exact reply comment, `setFailed`, no label. Applied to issues as well as PRs (the payload doesn't always carry `issue.pull_request`, and `lgtm` has no meaning on an issue anyway) — documented. `/approve` deliberately untouched: Prow lets author-approvers approve. |
| `/lgtm cancel` by author | allowed | Author can cancel/`/remove-lgtm` without reviewer auth; everyone else still needs it. |
| `/close` `/reopen` | "Authors and collaborators" | Author authorized without a collaborator lookup (asserted `notCalled`). Unauthorized still silently no-ops (existing behaviour, re-pinned). |
| `/close not-planned` | lifecycle plugin | `state_reason: 'not_planned'`. Plain `/close` body is unchanged — pinned with `toEqual` so no `state_reason` sneaks in. |

## Fixture trap worth knowing
`issueCommentEvent.json` has **author == commenter == Codertocat**, so the self-LGTM guard and author-close would silently flip existing tests. The lgtm/close/reopen test files now set `issue.user.login = 'some-author'` in `beforeEach` and the author-specific tests set it back explicitly. The bundle harness `/close` non-collaborator scenario is now explicitly non-*author* too. Every changed setup/assertion is listed in the commit messages.

## Testing
- [x] Failing-test-first for the self-LGTM guard and `/close not-planned` (red output in the delegated report; 4 and 6 failures respectively before the fix)
- [x] `npm run all` green — 30 files, **322 tests** (was 310); coverage 89.4 / 90.5 br / 97.3 fn
- [x] Two new bundle-harness scenarios against `dist/index.js`: author `/lgtm` refused (reply comment, no label, exit 1); `/close not-planned` PATCH body
- [x] Hermetic under a simulated Actions env; `dist/` byte-identical across repeated packs
