### PR TITLE
docs: bring documentation in line with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -16,6 +16,8 @@ Please describe the tests that you ran, created, or modified in order to verify 
 ## Checklist
 
 - [ ] I ran `npm run all` to lint and build my code
+- [ ] I ran `npm run pack` and committed `dist/`
+- [ ] Commits are signed off (DCO)
 - [ ] Note any new dependencies these changes bring in
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project is inspired by [Prow](https://github.com/kubernetes/test-infra/tree
 
 Check out the _"EXAMPLE"_ issues and pull requests (open and closed) in this repo to see how this works!
 
+These docs describe `main`. Features added since the latest release (`v2.0.0`) ship in the next release, which also creates the floating `v2` tag; until then pin `@v2.0.0` for the released behaviour. The action requires the `node24` runtime (GitHub requires actions/runner 2.327.1 or newer for node24 on self-hosted runners) and works on GitHub Enterprise Server via `GITHUB_API_URL`.
+
 ---
 Run specified actions or jobs for issue and PR comments through a `workflow.yaml` file:
 
@@ -17,15 +19,22 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
       - uses: cncf/prow-github-actions@v2
         with:
-          prow-commands: /assign /unassign /approve /retitle /area /kind /priority /label /remove /lgtm /close /reopen /lock /milestone /hold /cc /uncc /lifecycle /help
+          prow-commands: /assign /unassign /cc /uncc /approve /lgtm /hold /close /reopen /lock /retitle /milestone /remove /area /kind /priority /label /lifecycle /stage /status /help /good-first-issue /meow
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
+
+This is the full list of available commands. Prow-style aliases (`/unhold`, `/remove-kind`, ...) come with their base command, and listing an alias enables the whole command family.
 
 You can automatically merge PRs based on a cron schedule if it contains the `lgtm` label:
 
@@ -34,6 +43,10 @@ name: Merge on lgtm label
 on:
   schedule:
     - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   execute:
@@ -54,6 +67,9 @@ Prow Github actions also supports removing the lgtm label when a PR is updated
 name: Run Jobs on PR
 on: pull_request
 
+permissions:
+  pull-requests: write
+
 jobs:
   execute:
     runs-on: ubuntu-latest
@@ -68,8 +84,7 @@ jobs:
 - [Overview](./docs/overview.md)
 - [Commands](./docs/commands.md)
 - [Labeling](./docs/labeling.md)
-- [PR Labeling](./docs/pr-labeling.md)
-- [Cron Jobs](./docs/cron-jobs.md)
+- [Cron Jobs](./docs/cron-jobs.md) (includes the deprecated PR labeler)
 - [Automatic PR merging](./docs/automatic-merging.md)
 - [PR jobs](./docs/pr-jobs.md)
 - [Examples](./docs/examples.md)

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command, and listing an alias enables the whole command family (e.g. /remove-kind also enables /kind).
     required: false
   jobs:
-    description: The jobs to automatically run on event. Space delimited. Expect commands on own line.
+    description: The jobs to automatically run on event. Space delimited, on a single line.
     required: false
   merge-method:
     description: "Strategy for Prow-github-actions to take when merging a pull request using the lgtm cron-job. Can be 'squash', 'rebase', or 'merge'. Defaults to 'merge'"

--- a/docs/automatic-merging.md
+++ b/docs/automatic-merging.md
@@ -1,7 +1,7 @@
 # Automatic PR merging
 
 Prow github actions supports automatic PR merging through
-[Github actions cron jobs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).
+[Github actions cron jobs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).
 
 ```yaml
 name: Merge on lgtm label
@@ -9,11 +9,15 @@ on:
   schedule:
     - cron: '0 * * * *'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: cncf/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v2
         with:
           jobs: lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
@@ -25,28 +29,17 @@ jobs:
 This Github workflow will check every hour
 for PRs with the `lgtm` label and will attempt to automatically merge them.
 If the `hold` label is present, it will block automatic merging.
+Locked and closed PRs are skipped. An unknown `merge-method` falls back to `merge`.
+A merge failure is logged at debug level and does **not** fail the run.
 
-The following workflow is meant to run on PR update / creation and integrates into the `lgtm` family of jobs.
-```yaml
-name: Run Jobs on PR
-on: pull_request
-
-jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cncf/prow-github-actions@v1
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-```
-This workflow will remove the `lgtm` label from a PR that gets updated.
+The companion `lgtm` PR job removes the `lgtm` label from a PR that gets updated.
 This prevents any un-reviewed code from being automatically merged by the lgtm-merger mechanism.
+See [PR jobs](./pr-jobs.md) for the full workflow.
 
 Refer to the [lgtm command](./commands.md) and the [PR jobs](./pr-jobs.md) for further reference.
 
 ## Known limitations
-This job pulls PRs from github in batches of 100. This _may_ trigger a state
+This job pages through the repository's open PRs, following pages until one comes back empty. This _may_ trigger a state
 where github rate limits Prow github actions.
 This may only happen with very large projects.
 Please open an issue if you see this consistently happen.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,24 +1,37 @@
 # Prow github actions commands
 
-A command must start a line of the comment (leading whitespace is allowed); a command mentioned mid-sentence is ignored. Commands inside Markdown code (fenced ``` / ~~~ blocks, indented code, inline `code`) and blockquotes are ignored. Commands, their keywords and label values are case-insensitive (`/LGTM cancel` and `/kind Bug` work; the label is applied with the casing from `.prowlabels.yaml`), while milestone titles are matched exactly. Prow-style aliases such as `/remove-lgtm` and `/unhold` are enabled together with their base command. Listing an alias in `prow-commands` enables the whole command family: configuring only `/remove-kind` also enables `/kind`, and only `/unhold` also enables `/hold`. Any other lower-case `/<key>` listed in `prow-commands` is a [label command](./labeling.md#any-key-is-a-command) backed by the `<key>` section of `.prowlabels.yaml`. When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins; a `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
+These docs describe `main`. Features added since the latest release (`v2.0.0`) ship in the next release, which also creates the floating `v2` tag; until then pin `@v2.0.0` for the released behaviour.
+
+## Command syntax
+
+- A command must start a line of the comment; leading whitespace is allowed. A command mentioned mid-sentence is ignored.
+- Commands and their keywords (`cancel`, `clear`, `not-planned`) are case-insensitive: `/LGTM cancel` works.
+- **Label values** are matched case-insensitively against `.prowlabels.yaml` (or `.prowlabels.yml`, see [labeling](./labeling.md)) and applied with the casing written in the file: `/kind Bug` adds `kind/bug`.
+- `/lock` reasons are the exception: they are **case-sensitive**, and an unknown reason locks with no reason.
+- Commands inside Markdown code (fenced ``` / ~~~ blocks, indented code, inline `code`) and blockquotes are ignored.
+- When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins.
+- A `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
+- Milestone titles are matched exactly.
+- Prow-style aliases (`/remove-lgtm`, `/unhold`, ...) are enabled together with their base command. Listing an alias in `prow-commands` enables the whole command family: configuring only `/remove-kind` also enables `/kind`, and only `/unhold` also enables `/hold`.
+- Any other lower-case `/<key>` listed in `prow-commands` is a [label command](./labeling.md#any-key-is-a-command) backed by the `<key>` section of `.prowlabels.yaml`.
 
 Commands | Policy | Description
 --- | --- | ---
-`/approve` | [OWNERS](#owners) approver for **every** changed file if the repo has OWNERS files, otherwise Org members & Collaborators | approve all the files for the current PR
+`/approve` | [OWNERS](#owners) approver for **every** changed file if the repo has OWNERS files, otherwise Org members and Collaborators | approve all the files for the current PR
 `/approve no-issue` | same as `/approve` | same as `/approve`; accepted for Prow compatibility
-`/approve cancel` | same as `/approve` | removes your approval on this pull-request
+`/approve cancel` | same as `/approve` | dismisses the bot's latest approval on this pull-request
 `/remove-approve` | same as `/approve` | same as `/approve cancel`
 `/assign [@userA @userB @etc]` | anyone | Assign other users (or yourself if no one is specified). Target user must be Org Member, Collaborator, or have previously commented
-`/unassign [@userA @userB @etc]` | anyone | Unassigns specified people (or yourself if no one is specified). Target must have been already assigned.
-`/cc [@userA @userB @etc]` | anyone | Request review from specified people (or yourself if no one is specified). Target be an Org Member, Collaborator, or have previously commented.
-`/uncc [@userA @userB @etc]` | anyone | Dismiss review request for specified people (or yourself if no one is specified). Target must already have had a review requested.
+`/unassign [@userA @userB @etc]` | anyone | Unassigns specified people (or yourself if no one is specified). With targets, the commenter must be Org Member, Collaborator, or have previously commented. Target must have been already assigned.
+`/cc [@userA @userB @etc]` | anyone | Request review from specified people (or yourself if no one is specified). Self-cc requires Collaborator; targets must be an Org Member, Collaborator, or have previously commented.
+`/uncc [@userA @userB @etc]` | anyone | Dismiss review request for specified people (or yourself if no one is specified). Self-uncc requires Collaborator; with targets, the commenter must be Org Member, Collaborator, or have previously commented. Target must already have had a review requested.
 `/close` | Collaborators **or the issue/PR author** | closes the issue / PR
 `/close not-planned` | Collaborators **or the issue/PR author** | closes the issue / PR with the `not planned` state reason
 `/reopen` | Collaborators **or the issue/PR author** | reopens a closed issue / PR
-`/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason
-`/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone. An unknown title fails the run with the list of available milestones
+`/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason. Reasons are **case-sensitive**; an unknown reason locks with no reason
+`/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone. With no title the run fails. An unknown title fails the run with the list of available milestones
 `/milestone clear` | Collaborators | Removes the issue / PR from its milestone
-`/retitle some new title` | Collaborators | Renames the issue / PR
+`/retitle some new title` | Collaborators | Renames the issue / PR. With no title, nothing happens
 `/meow` | anyone | replies with a random cat image from [the cat API](https://thecatapi.com)
 
 Label Commands | Policy | Description
@@ -27,7 +40,7 @@ Label Commands | Policy | Description
 `/remove-area [label1 label2 ...]` | anyone | removes an area/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
 `/kind [label1 label2 ...]` | anyone | adds a kind/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
 `/remove-kind [label1 label2 ...]` | anyone | removes a kind/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
-`/lgtm` | [OWNERS](#owners) reviewer or approver for **at least one** changed file if the repo has OWNERS files, otherwise Collaborators and Org Members; **not the PR author** | adds the `lgtm` label. This is used for [automatic PR merging](./automatic-merging.md). Like Prow, you cannot LGTM your own PR; the guard also applies to issues since the label has no meaning there either
+`/lgtm` | [OWNERS](#owners) reviewer or approver for **at least one** changed file if the repo has OWNERS files, otherwise Org members and Collaborators; **not the PR author** | adds the `lgtm` label. This is used for [automatic PR merging](./automatic-merging.md). Like Prow, you cannot LGTM your own PR; the guard also applies to issues since the label has no meaning there either
 `/lgtm cancel` | same as `/lgtm`, **or the PR author** | removes the `lgtm` label
 `/remove-lgtm` | same as `/lgtm`, **or the PR author** | same as `/lgtm cancel`
 `/hold` | anyone | adds the `hold` label which prevents [automatic PR merging](./automatic-merging.md). Also see [lgtm removal on pr update](./pr-jobs.md)
@@ -51,7 +64,15 @@ Label Commands | Policy | Description
 `/remove-<key> [value1 value2 ...]` | anyone | removes `<key>/<value>` label(s) listed under `<key>` in [the `.prowlabels.yaml` file](./labeling.md)
 `/remove [label1 label2 ...]` | Collaborators | removes a specified label(s) on an issue / PR
 
-The `/remove-<key>` commands are enabled together with their base command and only remove values listed in `.prowlabels.yaml`, so anyone may use them without being able to strip `lgtm`, `hold` or `approved`. Use `/remove` for arbitrary labels.
+The `/remove-<key>` commands are enabled together with their base command and only remove values listed in `.prowlabels.yaml`, so anyone may use them without being able to strip `lgtm`, `hold` or `approved` — unless the repository lists those names under `labels:`, in which case `/remove-label` can remove them. Use `/remove` for arbitrary labels.
+
+## What happens when you are not authorized
+
+Failure behaviour differs per command:
+
+- `/close`, `/reopen` and `/retitle` silently do nothing.
+- `/lock`, `/remove` and `/milestone` fail the run.
+- `/lgtm` and `/approve` reply with a comment and fail the run.
 
 ## Enabling `/meow`
 
@@ -93,7 +114,7 @@ On a pull request the changed files are listed (for renames both the old and the
 
 - `/approve`: the commenter must be an `approver` for **every** changed file. The refusal names the first file that is not covered and the OWNERS files consulted for it.
 - `/lgtm`: the commenter must be a `reviewer` or `approver` for **at least one** changed file (Prow's lgtm rule).
-- On an issue there are no changed files, so the root `OWNERS` of the default branch is used as before.
+- On an issue there are no changed files, so the root `OWNERS` of the default branch is used.
 
 The `approvers` role does not grant `/lgtm` on its own for issues; on pull requests an approver of a changed file may also `/lgtm`.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,27 +6,35 @@ All commits must be signed off (`git commit -s`) to satisfy the DCO check.
 
 ## Development
 
+Node 24 or newer is required.
+
 ```sh
 npm ci
 npm run all   # build, lint, pack the dist/ bundle, and test
 ```
 
+Note that `npm run all` runs `lint:fix` first, which rewrites files in place.
+
 The action runs from the committed `dist/index.js` (an `ncc` bundle of `src/`).
 Any change to `src/` must be followed by `npm run pack`, and the resulting
 `dist/index.js` committed alongside it; CI fails if `dist/` is out of date.
 
-`tsc` compiles `src/` to ES modules under `lib/`, and `ncc` bundles those into
-the CommonJS `dist/index.js` that the runner executes; `package.json`
-intentionally has no `"type": "module"`, since Node would then refuse to load
-the bundle. Never import from `@actions/github/lib/*` (only `.` and
-`./lib/utils` are exported); the `Context` type lives in `src/utils/context.ts`.
+`tsc` compiles `src/` to ES modules under `lib/` (which is gitignored), and
+`ncc` bundles those into the CommonJS `dist/index.js` that the runner executes;
+`package.json` intentionally has no `"type": "module"`, since Node would then
+refuse to load the bundle. Never import from `@actions/github/lib/*` (only `.`
+and `./lib/utils` are exported); the `Context` type lives in
+`src/utils/context.ts`.
+
+[Dependabot](../.github/dependabot.yml) keeps npm dependencies and pinned
+actions up to date on a weekly schedule.
 
 ## Testing
 
 | Command | What it runs |
 |---------|--------------|
 | `npm test` | The whole Vitest suite |
-| `npm run test:coverage` | The suite with v8 coverage and the thresholds in `vitest.config.mjs` |
+| `npm run test:coverage` | The suite with v8 coverage; CI enforces the thresholds in `vitest.config.mjs` (lines 85, branches 83, functions 91, statements 85) |
 | `npx vitest run __tests__/bundle` | Only the bundle acceptance harness |
 
 Unit tests under `__tests__/` import `src/` directly and mock the GitHub API

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -1,58 +1,46 @@
 # Cron jobs
 
 The following jobs are supported through [cron Github workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).
+The `jobs` input is space delimited on a single line (`jobs: lgtm`); multi-line `jobs:` blocks do not work.
+Both jobs page through the repository's pull requests, following pages until one comes back empty, and skip locked and closed PRs.
 
 Jobs | Description
 --- | ---
-`lgtm` | Will attempt to automatically merge a PR with the `lgtm` label. Blocked by the `hold` label. Removed by the [lgtm PR job on pr update](./pr-jobs.md)
-`pr-labeler` | **(DEPRECATED)** Labels PRs with labels based on file globs found in `.github/labels.yaml`. See [docs on PR labeler for more info](pr-labeling.md)
+`lgtm` | Will attempt to automatically merge a PR with the `lgtm` label. Blocked by the `hold` label. See [automatic PR merging](./automatic-merging.md). Removed by the [lgtm PR job on pr update](./pr-jobs.md)
+`pr-labeler` | **(DEPRECATED)** Labels PRs with labels based on file globs found in `.github/labels.yaml` (or `.yml`)
 
-> What is the Chron job PR labeler?
+## `pr-labeler` (deprecated)
 
-This job is a legacy feature of Github Prow bot which would label PRs
-based on a chron schedule. This was created since Github at the time did not provide a way
-to securely run actions (and therefore code) from PR forks, which could possibly be untrusted.
-This chron job runs from _the main branch_ and not forks, therefore preventing any
-forked malicious code from being run against the repository.
+The `pr-labeler` cron job predates GitHub's `pull_request_target` trigger, which lets
+[`actions/labeler`](https://github.com/actions/labeler) label PRs from forks securely on
+each event instead of sweeping every open PR on a schedule. Use `actions/labeler` for new
+setups; this job remains for repositories that need to batch label all their PRs.
 
-> Why don't you recommend using it anymore?
-
-Github now has a solution! You can use the [Github labeler](https://github.com/actions/labeler)
-which uses a newer action trigger: `pull_request_target`.
-This is [documented here](https://github.com/actions/labeler/blob/main/README.md).
-The new action trigger event does _not_ run from the forked branch
-but rather, runs from the _main branch_. It can be triggered on each occurence of a PR.
-
-Since this is officially supported by Github, I am recommending people use that to label their PRs.
-
-> Why not just remove the chron labeler all together?
-
-I'm keeping this job as part of the API since it may have additional purposes.
-The chron job will attempt to run on _all PRs_ in a repository
-which may be useful if a repository needs to batch label all their PRs.
-
-However, this has some known limitations. The chron labeler queries Github in 100 batch PRs.
-This can trigger github to rate limit the bot.
+The job reads `.github/labels.yaml` (or `.github/labels.yml`) from the repository, maps
+labels to file globs, and labels every open, unlocked PR whose changed files match.
 
 This job may be run with the following workflow configuration:
 
-```yml
+```yaml
 name: Label PRs from globs
 on:
   schedule:
     - cron: '0 * * * *'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: cncf/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v2
         with:
           jobs: pr-labeler
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-> Interesting! Where's the historical context?
-
-Refer to this thread and this comment for further discussion on the new action handler:
-https://github.com/actions/labeler/issues/12#issuecomment-670967607
+Querying every open PR on a schedule may hit GitHub rate limits on very large projects.
+For the historical discussion see
+[actions/labeler#12](https://github.com/actions/labeler/issues/12#issuecomment-670967607).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,8 +1,10 @@
 # Examples
 
 * [`.prowlabels.yaml`](#prowlabelsyaml)
-* [Review and Approve Pull Requests](#review-and-approve-pull-requests)
+* [Review and approve pull requests](#review-and-approve-pull-requests)
 * [All prow github actions](#all-prow-github-actions)
+* [A dynamic label command](#a-dynamic-label-command)
+* [`/meow`](#meow)
 * [PR Labeler](#pr-labeler)
 * [Automatic PR merger](#automatic-pr-merger)
 * [PR job to remove lgtm label on update](#pr-job-to-remove-lgtm-label-on-update)
@@ -24,9 +26,21 @@ priority:
   - low
   - mid
   - high
+
+# plain labels applied verbatim by /label
+labels:
+  - documentation
+  - question
+
+# mapping form: a later /triage replaces any existing triage/* label
+triage:
+  values:
+    - accepted
+    - needs-information
+  exclusive: true
 ```
 
-## Review and Approve Pull Requests
+## Review and approve pull requests
 
 Below is an example of how to use [OWNERS](./commands.md#owners) files with the Prow action.
 
@@ -70,20 +84,22 @@ permissions:
   issues: write
   # Allow adding a review to a pull request
   pull-requests: write
+  # Allow reading the repository
+  contents: read
 
 jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: cncf/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v2
         with:
-          prow-commands: |
-            /approve
-            /lgtm
+          prow-commands: /approve /lgtm
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-### All prow github actions
+## All prow github actions
+
+The full list of available commands is kept in the [README quickstart](../README.md#quickstart). Aliases (`/unhold`, `/remove-kind`, ...) come with their base command. One short example:
 
 ```yaml
 name: Prow github actions
@@ -91,38 +107,85 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: cncf/prow-github-actions@v1
+      - uses: cncf/prow-github-actions@v2
         with:
-          prow-commands: |
-            /assign
-            /unassign
-            /approve
-            /retitle
-            /area
-            /kind
-            /priority
-            /remove
-            /lgtm
-            /close
-            /reopen
-            /lock
-            /milestone
-            /hold
-            /cc
-            /uncc
+          prow-commands: /assign /approve /retitle /area /kind /priority /lgtm /close /reopen /hold /cc /uncc
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-### PR Labeler
+## A dynamic label command
+
+Any top level key of `.prowlabels.yaml` becomes a `/<key>` command once listed in `prow-commands`:
+
+```yaml
+name: Triage commands
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          prow-commands: /triage
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```
+
+With the `triage` section of the [`.prowlabels.yaml`](#prowlabelsyaml) above, `/triage accepted` labels the issue or PR with `triage/accepted`.
+
+## `/meow`
+
+`/meow` replies with a random cat image. It is opt in and calls a third party provider; see [Enabling `/meow`](./commands.md#enabling-meow).
+
+```yaml
+name: Meow
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          prow-commands: /meow
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+          # this is optional; provide it from a repository secret
+          cat-api-key: '${{ secrets.CAT_API_KEY }}'
+```
+
+## PR Labeler
 Use the Github actions/labeler which now supports `pull_request_target`
 ```yaml
 name: Pull Request Labeler
 on:
   - pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   triage:
@@ -133,34 +196,8 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-### Automatic PR merger
-```yaml
-name: Merge on lgtm label
-on:
-  schedule:
-    - cron: '0 * * * *'
+## Automatic PR merger
+See [automatic PR merging](./automatic-merging.md) for the full workflow.
 
-jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cncf/prow-github-actions@v1
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-```
-
-### PR job to remove lgtm label on update
-```yaml
-name: Run Jobs on PR
-on: pull_request
-
-jobs:
-  execute:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: cncf/prow-github-actions@v1
-        with:
-          jobs: lgtm
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-```
+## PR job to remove lgtm label on update
+See [PR jobs](./pr-jobs.md) for the full workflow.

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -1,6 +1,7 @@
 # Labeling
 
 Prow github actions expects the file `.prowlabels.yaml` to be in the root of the project.
+If it is absent, `.prowlabels.yml` is used as a fallback.
 This is needed for most labeling commands and jobs.
 All of the following examples can be placed simultaneously in the `.prowlabels.yaml` file.
 
@@ -20,51 +21,32 @@ optional `exclusive` flag:
 
 ```yaml
 # plain list: labels stack
-triage:
-  - accepted
-  - needs-information
+area:
+  - bug
+  - important
 
-# mapping: a later /level replaces any existing level/* label
-level:
+# mapping: a later /triage replaces any existing triage/* label
+triage:
   values:
-    - sandbox
-    - incubation
-    - graduation
-    - archived
+    - accepted
+    - needs-information
   exclusive: true
 ```
 
-With `prow-commands: /triage /level`, the commands `/triage accepted` and
-`/level incubation` label the issue or PR with `triage/accepted` and `level/incubation`.
-Because `level` is `exclusive`, `/level graduation` on that issue removes
-`level/incubation` before adding `level/graduation`.
+With `prow-commands: /area /triage`, the commands `/area bug` and
+`/triage accepted` label the issue or PR with `area/bug` and `triage/accepted`.
+Because `triage` is `exclusive`, `/triage needs-information` on that issue removes
+`triage/accepted` before adding `triage/needs-information`. Exclusivity applies to
+labels already on the issue, not to the current comment: every requested value is
+kept, so `/priority low high` adds both `priority/low` and `priority/high`.
 
 A key name must be lower case and consist of letters, digits and dashes
 (`^[a-z][a-z0-9-]*$`) to be usable as a command. Listing a `/<key>` in `prow-commands`
 whose section is missing from the yaml fails the run with
-`<key>: yaml malformed, expected '<key>' top level key`.
-
-## Area labels
-
-```yaml
-area:
-  - bug
-  - important
-```
-
-With the command `/area bug`,
-the issue or PR will be labeled with `area/bug`
-
-## Kind labels
-
-```yaml
-kind:
-  - failing-test
-  - cleanup
-```
-
-With the command `/kind cleanup`,
-the issue or PR will be labeled with `kind/cleanup`
+`could not get labels from yaml: Error: <key>: yaml malformed, expected '<key>' top level key`.
+A section that is neither a list of values nor a `{ values: [...], exclusive: bool }`
+mapping fails the run with
+`could not get labels from yaml: Error: <key>: yaml malformed, expected a list of values or { values: [...], exclusive: bool }`.
 
 ## Priority labels
 
@@ -84,12 +66,12 @@ the issue or PR will be labeled with `priority/low`.
 
 ```yaml
 labels:
-  - good-first-issue
-  - help-wanted
+  - documentation
+  - question
 ```
 
-With the command `/label good-first-issue`,
-the issue or PR will be labeled with `good-first-issue` as written, with no prefix.
+With the command `/label documentation`,
+the issue or PR will be labeled with `documentation` as written, with no prefix.
 Values are split on spaces, so label names containing spaces cannot be listed here.
 
 ## Lifecycle, stage and status labels
@@ -129,18 +111,14 @@ Command | Adds | `/remove-` form removes
 `/help` | `help wanted` | `help wanted`, `good first issue`
 `/good-first-issue` | `good first issue`, `help wanted` | `good first issue`
 
+Removal matches label names **case-sensitively**, unlike the prefixed label
+commands: `/remove-help` does not remove a label spelled `Help Wanted`.
+
 ## Removing labels
 
-Every label command has a `/remove-` form that takes the same values:
-`/remove-area bug` removes `area/bug`, `/remove-kind cleanup` removes
-`kind/cleanup`, `/remove-priority low` removes `priority/low`,
-`/remove-label help-wanted` removes `help-wanted` and `/remove-level sandbox`
-removes `level/sandbox`.
-Only values listed under the matching key in `.prowlabels.yaml` are
-removed, so these commands can be used by anyone without exposing
-labels such as `lgtm`, `hold` or `approved`. A value that is not on
-the issue is ignored. Enabling `/kind` in `prow-commands` also enables
-`/remove-kind`, and listing only `/remove-kind` enables `/kind` as well.
+Every label command has a `/remove-` form that takes the same values and only
+removes values listed in `.prowlabels.yaml`. See
+[commands](./commands.md) for the full list and policy.
 
 ## Automatic PR labels
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,9 +15,10 @@ that can be run with specific [Github "events"](https://docs.github.com/en/actio
 ## Read more
 - [Prow github actions available commands](./commands.md)
 - [Labeling issues](./labeling.md)
-- [Automatically Labeling PRs](./pr-labeling.md)
+- [Automatically Labeling PRs](./cron-jobs.md) (deprecated cron `pr-labeler` job)
 - [Automatic PR merging](./automatic-merging.md)
   - [Available cron jobs](./cron-jobs.md)
 - [Jobs to run on PR update](./pr-jobs.md)
 - [Examples](./examples.md)
 - [Releasing](./releasing.md)
+- [Contributing](./contributing.md)

--- a/docs/pr-jobs.md
+++ b/docs/pr-jobs.md
@@ -2,4 +2,25 @@
 
 Jobs | Description
 --- | ---
-`lgtm` | Will remove the lgtm label (if present) upon PR update. Prevents un-reviewed code from being merged. Refer to the [automatic merging docs](./automatic-merging.md) for further reference.
+`lgtm` | Removes the `lgtm` label (if present) when the PR is updated, so updated code must be reviewed again before [automatic merging](./automatic-merging.md).
+
+`lgtm` is the only PR job.
+
+```yaml
+name: Run Jobs on PR
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```
+
+The default `pull_request` activity types (`opened`, `synchronize`, `reopened`) are the ones you want; `labeled` is not needed and would not self-trigger removal.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,7 +18,8 @@ Both workflows:
    (`npm run pack`). The release fails if `dist/` is out of date.
 2. **Generate an SBOM** of the runtime dependencies in SPDX 2.3 JSON format
    using [waybill](https://github.com/kusari-oss/waybill) (pinned version,
-   SHA256-verified download; dev/build/test scopes excluded).
+   SHA256-verified download; dev/build/test scopes excluded, `dist/` excluded
+   via `--exclude-path dist`).
 3. **Sign the SBOM** with [cosign](https://github.com/sigstore/cosign)
    (keyless, via GitHub OIDC) and create a SLSA build provenance
    attestation covering both `dist/index.js` and the SBOM.
@@ -30,7 +31,9 @@ Both workflows:
 
 For stable releases, `release.yml` additionally moves the floating major tag
 (`v2`, `v3`, …) to the new release so that `uses: cncf/prow-github-actions@v2`
-tracks the latest `v2.x.y`. Pre-releases never move the floating tag.
+tracks the latest `v2.x.y`. Pre-releases never move the floating tag. The `v2`
+floating tag does not exist until the first stable tag is pushed by this
+workflow; until then pin an exact release such as `@v2.0.0`.
 
 ## Cutting a stable release
 
@@ -98,8 +101,8 @@ gh attestation verify prow-github-actions-${VERSION}.spdx.json \
 ## Versioning
 
 Releases follow [SemVer](https://semver.org/) with `v`-prefixed tags
-(`v1.0.0`, `v2.0.0-rc.1`, `v2.0.0`, …). The floating major tag (`v2`) always
-points at the latest stable `v2.x.y` release:
+(`v1.0.0`, `v2.0.0-rc.1`, `v2.0.0`, …). Once it exists, the floating major tag
+(`v2`) always points at the latest stable `v2.x.y` release:
 
 ```yaml
 # track the latest v2.x.y


### PR DESCRIPTION
# Description

A full audit of the docs against the code on `main` (post #109–#139), then a rewrite of everything that was stale, wrong, contradictory, duplicated, or missing. Docs-only: `README.md`, `docs/**`, the `jobs` input description in `action.yml`, and the PR template. No code, tests, workflows or `dist/` changes; 459 tests unaffected.

Voice: matches the existing dense, declarative style of `commands.md`/`releasing.md` (tables, backticked commands, bold on the load-bearing word, YAML-first with inline comments, sentence-case headings). The chatty first-person Q&A in `cron-jobs.md` is retired.

## Must-fix items
- Broken `./docs/pr-labeling.md` link ×3 (README, overview, cron-jobs) — file never existed.
- `@v1` ×5 in examples/cron/merging → `@v2` everywhere, plus **one release-status note** in the README and commands.md: docs describe `main`; features since `v2.0.0` ship in the next release, which also creates the floating `v2` tag (it does not exist yet); pin `@v2.0.0` for released behaviour. No per-row "since" markers.
- `permissions:` blocks on every workflow snippet, mirroring the dogfood workflows.
- Policy corrections from code: `/cc`/`/uncc` self-use requires a collaborator; targeted `/unassign`/`/uncc` also check the commenter; `/approve cancel` dismisses the **bot's** latest approval, not "yours"; `/lgtm` and `/approve` fallback wording unified.
- The 900-character syntax paragraph → a "Command syntax" list; new "What happens when you are not authorized" section (close/reopen/retitle silently do nothing; lock/remove/milestone fail the run; lgtm/approve reply and fail).
- One canonical full command list (README); other pages link to it instead of carrying divergent copies. Merger/PR-job snippets deduplicated (were in 3 places).
- `labeling.md`: `.yml` fallback, surfaced error texts, exclusive-group semantics, `labels:` example no longer contradicts `/help`; matches the repo's own `.prowlabels.yaml`.
- `pr-jobs.md` expanded from 5 lines; `cron-jobs.md` rewritten; `contributing.md` gains Node ≥ 24, `lint:fix` side effect, coverage thresholds, dist gate, DCO.

## Behaviour the audit surfaced that is now documented honestly (not changed here)
These read like bugs or sharp edges; I'd file them as issues rather than fix them in a docs PR:
1. `/lock` reasons are **case-sensitive** (the only case-sensitive input) and an unknown reason locks with no reason; `/lock resolved` also passes no reason.
2. The `jobs:` input splits on a **single space**, so a multi-line `jobs: |` block fails — its own `action.yml` text said "on own line". Description corrected here.
3. `/remove-label` can strip `lgtm`/`hold` **if** a repo lists them under `labels:`.
4. Merge failures in the `lgtm` cron are debug-logged and do **not** fail the run.
5. `/help`/`/good-first-issue` removal compares label names case-sensitively, unlike prefixed labels.
6. The deprecated `pr-labeler` lists **all** PRs (no `state: open`) and filters client-side; listing APIs use the default page size, so the old "batches of 100" claim was wrong — pages are followed until empty.

## Verification
- `npx eslint README.md docs action.yml .github` → 0 issues (markdown rules: single H1, no empty links, no level skips)
- All 28 relative links and 7 anchors resolve (checked with `ls`/grep)
- Every audit item has a disposition; two audit claims were corrected against the code (`/lock resolved` behaviour; `pr-labeler` scope)
