### PR TITLE
fix: /lock reasons, whitespace-delimited jobs input, case-insensitive /remove-help

### DIFF
--- a/__tests__/cronJobTest/handleCronJob.test.ts
+++ b/__tests__/cronJobTest/handleCronJob.test.ts
@@ -1,10 +1,44 @@
 import * as core from '@actions/core'
-import { describe, expect, it, vi } from 'vitest'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
+import listPullReqs from '../fixtures/pullReq/pullReqListPulls.json'
 import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 
 import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+function serveMergeablePr() {
+  server.use(
+    http.get(`${utils.api}/repos/Codertocat/Hello-World/pulls`, ({ request }) => {
+      const page = new URL(request.url).searchParams.get('page')
+      const payload = structuredClone(listPullReqs)
+      payload[0].labels[0].name = 'lgtm'
+      return new Response(JSON.stringify(page === '1' ? payload : []), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }),
+  )
+  const mergeReq = new utils.ObserveRequest()
+  server.use(
+    http.put(
+      `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+      utils.mockResponse(200, null, mergeReq),
+    ),
+  )
+  return mergeReq
+}
 
 describe('handleCronJobs', () => {
   it('fails when the job is not supported', async () => {
@@ -29,5 +63,56 @@ describe('handleCronJobs', () => {
     expect(setFailed).toHaveBeenCalledWith(
       expect.stringContaining('please provide a list of space delimited commands / jobs to run'),
     )
+  })
+
+  it('dispatches jobs delimited by newlines', async () => {
+    utils.setupJobsEnv('lgtm\n')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    const mergeReq = serveMergeablePr()
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.toBeUndefined()
+    await expect(mergeReq.called()).resolves.toBe('called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('dispatches jobs delimited by newlines and extra spaces', async () => {
+    utils.setupJobsEnv('lgtm  pr-labeler\n')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    const mergeReq = serveMergeablePr()
+    const yamlFetch = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/files`,
+        utils.mockResponse(200, []),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yaml`,
+        utils.mockResponse(404, null, yamlFetch),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.github%2Flabels.yml`,
+        utils.mockResponse(404, null, yamlFetch),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.toBeUndefined()
+    await expect(mergeReq.called()).resolves.toBe('called')
+    await expect(yamlFetch.called()).resolves.toBe('called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('could not get .github/labels.yaml or .github/labels.yml'),
+    )
+  })
+
+  it('matches job names case-insensitively', async () => {
+    utils.setupJobsEnv('LGTM')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    const mergeReq = serveMergeablePr()
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.toBeUndefined()
+    await expect(mergeReq.called()).resolves.toBe('called')
+    expect(setFailed).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/issueCommentTest/lock.test.ts
+++ b/__tests__/issueCommentTest/lock.test.ts
@@ -128,8 +128,8 @@ describe('/lock', () => {
     })
   })
 
-  it('locks the associated issue with given reason resolved', async () => {
-    issueCommentEvent.comment.body = '/lock resolved'
+  it('locks the associated issue with given reason RESOLVED (case-insensitive)', async () => {
+    issueCommentEvent.comment.body = '/lock RESOLVED'
 
     server.use(
       http.get(
@@ -150,8 +150,89 @@ describe('/lock', () => {
 
     await handleIssueComment(commentContext)
     await observeReq.called()
-    // resolved is GitHub's default, so no lock_reason is sent
+    expect(await observeReq.body()).toMatchObject({
+      lock_reason: 'resolved',
+    })
+  })
+
+  it('locks the associated issue with given reason Too-Heated (case-insensitive)', async () => {
+    issueCommentEvent.comment.body = '/lock Too-Heated'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
+    expect(await observeReq.body()).toMatchObject({
+      lock_reason: 'too heated',
+    })
+  })
+
+  it('locks with no reason when none is given', async () => {
+    issueCommentEvent.comment.body = '/lock'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    await handleIssueComment(commentContext)
+    await observeReq.called()
     expect(await observeReq.ref?.text()).toBe('')
+  })
+
+  it('fails loudly on an unknown reason without locking', async () => {
+    issueCommentEvent.comment.body = '/lock bogus'
+
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/collaborators/Codertocat`,
+        utils.mockResponse(204),
+      ),
+    )
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/lock`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining('unknown reason "bogus"'),
+    )
   })
 
   it('fails when commenter is not a collaborator', async () => {

--- a/__tests__/label/help.test.ts
+++ b/__tests__/label/help.test.ts
@@ -94,6 +94,15 @@ describe('/help and /good-first-issue', () => {
     expect(setFailed).not.toHaveBeenCalled()
   })
 
+  it('/remove-help removes labels with the casing on the issue', async () => {
+    const { mutations } = serveIssueAndRecordMutations(['Help Wanted'])
+
+    const setFailed = await run('/help', '/remove-help')
+
+    expect(mutations).toEqual(['DELETE Help%20Wanted'])
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
   it('/remove-help is a no-op when neither label is on the issue', async () => {
     const { mutations } = serveIssueAndRecordMutations([])
 

--- a/__tests__/pullReqTest/handlePullReq.test.ts
+++ b/__tests__/pullReqTest/handlePullReq.test.ts
@@ -1,10 +1,41 @@
 import * as core from '@actions/core'
-import { expect, it, vi } from 'vitest'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest'
 import { handlePullReq } from '../../src/pullReq/handlePullReq'
 
+import issuePayload from '../fixtures/issues/issue.json'
 import prCreatedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 
 import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+function serveLgtmRemoval() {
+  const payload = structuredClone(issuePayload)
+  payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+  server.use(
+    http.get(
+      `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+      utils.mockResponse(200, payload),
+    ),
+  )
+  const deleteReq = new utils.ObserveRequest()
+  server.use(
+    http.delete(
+      `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+      utils.mockResponse(200, null, deleteReq),
+    ),
+  )
+  return deleteReq
+}
 
 it('ignores the jobs if not setup in environment', async () => {
   const spy = vi.spyOn(core, 'setFailed')
@@ -15,4 +46,39 @@ it('ignores the jobs if not setup in environment', async () => {
 
   await handlePullReq(runContext)
   expect(spy).toHaveBeenCalled()
+})
+
+it('dispatches jobs delimited by newlines', async () => {
+  utils.setupJobsEnv('lgtm\n')
+  const runContext = new utils.MockContext(prCreatedEvent)
+  const deleteReq = serveLgtmRemoval()
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  await expect(deleteReq.called()).resolves.toBe('called')
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('dispatches jobs delimited by newlines and extra spaces', async () => {
+  utils.setupJobsEnv('lgtm  pr-labeler\n')
+  const runContext = new utils.MockContext(prCreatedEvent)
+  const deleteReq = serveLgtmRemoval()
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  await expect(deleteReq.called()).resolves.toBe('called')
+  expect(setFailed).toHaveBeenCalledWith(
+    expect.stringContaining('could not execute pr-labeler'),
+  )
+})
+
+it('matches job names case-insensitively', async () => {
+  utils.setupJobsEnv('LGTM')
+  const runContext = new utils.MockContext(prCreatedEvent)
+  const deleteReq = serveLgtmRemoval()
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  await expect(deleteReq.called()).resolves.toBe('called')
+  expect(setFailed).not.toHaveBeenCalled()
 })

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command, and listing an alias enables the whole command family (e.g. /remove-kind also enables /kind).
     required: false
   jobs:
-    description: The jobs to automatically run on event. Space delimited, on a single line.
+    description: The jobs to automatically run on event. Space or newline delimited.
     required: false
   merge-method:
     description: "Strategy for Prow-github-actions to take when merging a pull request using the lgtm cron-job. Can be 'squash', 'rebase', or 'merge'. Defaults to 'merge'"

--- a/dist/index.js
+++ b/dist/index.js
@@ -45079,6 +45079,12 @@ async function close_close(context = github_context) {
 
 
 
+const lockReasons = {
+    'resolved': 'resolved',
+    'off-topic': 'off-topic',
+    'too-heated': 'too heated',
+    'spam': 'spam',
+};
 /**
  * /lock will lock the issue / PR.
  * No more comments will be permitted
@@ -45105,78 +45111,23 @@ async function lock(context = github_context) {
         throw new Error(`could not check commenter auth: ${e}`);
     }
     if (isAuthUser) {
+        let lockReason;
         if (commentArgs.length > 0) {
-            switch (commentArgs[0]) {
-                case 'resolved':
-                    try {
-                        await octokit.issues.lock({
-                            ...context.repo,
-                            issue_number: issueNumber,
-                        });
-                    }
-                    catch (e) {
-                        throw new Error(`could not lock issue: ${e}`);
-                    }
-                    break;
-                case 'off-topic':
-                    try {
-                        await octokit.issues.lock({
-                            ...context.repo,
-                            issue_number: issueNumber,
-                            lock_reason: 'off-topic',
-                        });
-                    }
-                    catch (e) {
-                        throw new Error(`could not lock issue: ${e}`);
-                    }
-                    break;
-                case 'too-heated':
-                    try {
-                        await octokit.issues.lock({
-                            ...context.repo,
-                            issue_number: issueNumber,
-                            lock_reason: 'too heated',
-                        });
-                    }
-                    catch (e) {
-                        throw new Error(`could not lock issue: ${e}`);
-                    }
-                    break;
-                case 'spam':
-                    try {
-                        await octokit.issues.lock({
-                            ...context.repo,
-                            issue_number: issueNumber,
-                            lock_reason: 'spam',
-                        });
-                    }
-                    catch (e) {
-                        throw new Error(`could not lock issue: ${e}`);
-                    }
-                    break;
-                default:
-                    try {
-                        await octokit.issues.lock({
-                            ...context.repo,
-                            issue_number: issueNumber,
-                        });
-                    }
-                    catch (e) {
-                        throw new Error(`could not lock issue: ${e}`);
-                    }
-                    break;
+            const arg = commentArgs[0].toLowerCase();
+            lockReason = lockReasons[arg];
+            if (lockReason === undefined) {
+                throw new Error(`/lock: unknown reason "${commentArgs[0]}". Use resolved, off-topic, too-heated or spam`);
             }
         }
-        else {
-            try {
-                await octokit.issues.lock({
-                    ...context.repo,
-                    issue_number: issueNumber,
-                });
-            }
-            catch (e) {
-                throw new Error(`could not lock issue: ${e}`);
-            }
+        try {
+            await octokit.issues.lock({
+                ...context.repo,
+                issue_number: issueNumber,
+                ...(lockReason !== undefined ? { lock_reason: lockReason } : {}),
+            });
+        }
+        catch (e) {
+            throw new Error(`could not lock issue: ${e}`);
         }
     }
     else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -43781,59 +43781,6 @@ function isNotFound(error) {
         && error.status === 404);
 }
 
-;// CONCATENATED MODULE: ./lib/labels/fixed.js
-
-
-
-// Prow's help plugin: label names contain spaces so they bypass .prowlabels.yaml
-const fixedLabelCommands = [
-    { command: '/help', add: ['help wanted'], remove: ['help wanted', 'good first issue'] },
-    { command: '/good-first-issue', add: ['good first issue', 'help wanted'], remove: ['good first issue'] },
-];
-/**
- * addFixedLabels labels the issue with the command's fixed labels
- *
- * @param context - the github actions event context
- * @param cmd - the command definition
- */
-async function addFixedLabels(context, cmd) {
-    const token = getInput('github-token', { required: true });
-    const octokit = newOctokit(token);
-    await labelIssue(octokit, context, requireIssueNumber(context), cmd.add);
-}
-/**
- * removeFixedLabels removes the command's fixed labels that are on the issue
- *
- * @param context - the github actions event context
- * @param cmd - the command definition
- */
-async function removeFixedLabels(context, cmd) {
-    const token = getInput('github-token', { required: true });
-    const octokit = newOctokit(token);
-    const issueNumber = requireIssueNumber(context);
-    let currentLabels = [];
-    try {
-        currentLabels = await getCurrentLabels(octokit, context, issueNumber);
-        core_debug(`${cmd.command.slice(1)}: found labels for issue ${currentLabels}`);
-    }
-    catch (e) {
-        throw new Error(`could not get labels from issue: ${e}`);
-    }
-    const present = cmd.remove.filter(label => currentLabels.includes(label));
-    if (present.length === 0) {
-        core_debug(`${cmd.command.slice(1)}: none of ${cmd.remove} are on the issue`);
-        return;
-    }
-    await removeLabels(octokit, context, issueNumber, present);
-}
-function requireIssueNumber(context) {
-    const issueNumber = context.payload.issue?.number;
-    if (issueNumber === undefined) {
-        throw new Error(`github context payload missing issue number: ${context.payload}`);
-    }
-    return issueNumber;
-}
-
 ;// CONCATENATED MODULE: ./lib/utils/command.js
 /**
  * hasCommand reports whether the command starts a line of the body
@@ -43984,6 +43931,201 @@ function stripAtSign(args) {
         }
     }
     return toReturn;
+}
+
+;// CONCATENATED MODULE: ./lib/labels/prefixed.js
+
+
+
+
+const prefixedLabelCommands = [
+    { command: '/area', prefix: 'area', allowlistKey: 'area' },
+    { command: '/kind', prefix: 'kind', allowlistKey: 'kind' },
+    { command: '/priority', prefix: 'priority', allowlistKey: 'priority', exclusive: true },
+    { command: '/label', prefix: '', allowlistKey: 'labels' },
+    { command: '/lifecycle', prefix: 'lifecycle', allowlistKey: 'lifecycle', exclusive: true, defaultValues: ['frozen', 'stale', 'rotten'] },
+    { command: '/stage', prefix: 'stage', allowlistKey: 'stage', exclusive: true, defaultValues: ['alpha', 'beta', 'stable'] },
+    { command: '/status', prefix: 'status', allowlistKey: 'status', exclusive: true, defaultValues: ['approved-for-milestone', 'in-progress', 'in-review'] },
+];
+// a .prowlabels.yaml key usable as a slash command: lower-case letters, digits and dashes
+const labelCommandName = /^[a-z][a-z0-9-]*$/;
+/**
+ * dynamicPrefixedCommand builds the command for an arbitrary .prowlabels.yaml
+ * key so that `/<key> value` labels the issue with '<key>/value'
+ *
+ * @param name - the top level key, ex: 'level'
+ */
+function dynamicPrefixedCommand(name) {
+    return { command: `/${name}`, prefix: name, allowlistKey: name };
+}
+/**
+ * removeCommandFor returns the Prow-style removal spelling of a label command
+ * Ex: '/kind' -> '/remove-kind'
+ *
+ * @param command - the add form of the command
+ */
+function removeCommandFor(command) {
+    return `/remove-${command.slice(1)}`;
+}
+/**
+ * addPrefixedLabels labels the issue with '<prefix>/<value>' for every value
+ * that is both in the comment and in the .prowlabels.yaml allowlist.
+ * When the command is exclusive, existing '<prefix>/*' labels that were not
+ * requested are removed first.
+ *
+ * @param context - the github actions event context
+ * @param cmd - the command definition
+ */
+async function addPrefixedLabels(context, cmd) {
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    const issueNumber = requireIssueNumber(context);
+    const commentBody = context.payload.comment?.body;
+    const section = await allowlistFor(octokit, context, cmd);
+    const labels = requestedLabels(cmd, cmd.command, commentBody, section.values);
+    if (section.exclusive) {
+        const currentLabels = await currentIssueLabels(octokit, context, issueNumber, cmd.command);
+        const stale = currentLabels.filter((label) => {
+            return label.toLowerCase().startsWith(`${cmd.prefix.toLowerCase()}/`)
+                && !labels.some(requested => sameLabel(requested, label));
+        });
+        if (stale.length > 0) {
+            await removeLabels(octokit, context, issueNumber, stale);
+        }
+    }
+    await labelIssue(octokit, context, issueNumber, labels);
+}
+/**
+ * removePrefixedLabels removes '<prefix>/<value>' for every value in the
+ * /remove-<command> line that is in the .prowlabels.yaml allowlist and
+ * currently on the issue. Restricting removal to the allowlist keeps
+ * anyone from stripping protected labels such as lgtm, approved or hold.
+ *
+ * @param context - the github actions event context
+ * @param cmd - the command definition
+ */
+async function removePrefixedLabels(context, cmd) {
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    const issueNumber = requireIssueNumber(context);
+    const commentBody = context.payload.comment?.body;
+    const command = removeCommandFor(cmd.command);
+    const section = await allowlistFor(octokit, context, cmd);
+    const labels = requestedLabels(cmd, command, commentBody, section.values);
+    const currentLabels = await currentIssueLabels(octokit, context, issueNumber, command);
+    const present = currentLabels.filter(label => labels.some(requested => sameLabel(requested, label)));
+    if (present.length === 0) {
+        core_debug(`${command.slice(1)}: none of ${labels} are on the issue`);
+        return;
+    }
+    await removeLabels(octokit, context, issueNumber, present);
+}
+function requireIssueNumber(context) {
+    const issueNumber = context.payload.issue?.number;
+    if (issueNumber === undefined) {
+        throw new Error(`github context payload missing issue number: ${context.payload}`);
+    }
+    return issueNumber;
+}
+// the yaml section wins over the built-in defaults; a yaml `exclusive` wins over the registry
+async function allowlistFor(octokit, context, cmd) {
+    const key = cmd.allowlistKey;
+    try {
+        const section = (await getLabelConfig(octokit, context))[key];
+        if (section) {
+            core_debug(`${key}: found labels ${section.values}`);
+            return { values: section.values, exclusive: section.exclusive ?? cmd.exclusive ?? false };
+        }
+        if (cmd.defaultValues) {
+            core_debug(`${key}: using built-in labels ${cmd.defaultValues}`);
+            return { values: cmd.defaultValues, exclusive: cmd.exclusive ?? false };
+        }
+        throw new Error(`${key}: yaml malformed, expected '${key}' top level key`);
+    }
+    catch (e) {
+        throw new Error(`could not get labels from yaml: ${e}`);
+    }
+}
+function requestedLabels(cmd, command, commentBody, allowed) {
+    const args = getCommandArgs(command, commentBody);
+    const canonical = new Map(allowed.map(value => [value.toLowerCase(), value]));
+    const values = args
+        .map(arg => canonical.get(arg.toLowerCase()))
+        .filter((value) => value !== undefined);
+    const labels = addPrefix(cmd.prefix, [...new Set(values)]);
+    // no arguments after command provided
+    if (labels.length === 0) {
+        throw new Error(`${command.slice(1)}: command args missing from body`);
+    }
+    return labels;
+}
+// GitHub label names are case-insensitive, as are Prow's comparisons
+function sameLabel(a, b) {
+    return a.toLowerCase() === b.toLowerCase();
+}
+async function currentIssueLabels(octokit, context, issueNumber, command) {
+    try {
+        const currentLabels = await getCurrentLabels(octokit, context, issueNumber);
+        core_debug(`${command.slice(1)}: found labels for issue ${currentLabels}`);
+        return currentLabels;
+    }
+    catch (e) {
+        throw new Error(`could not get labels from issue: ${e}`);
+    }
+}
+
+;// CONCATENATED MODULE: ./lib/labels/fixed.js
+
+
+
+
+// Prow's help plugin: label names contain spaces so they bypass .prowlabels.yaml
+const fixedLabelCommands = [
+    { command: '/help', add: ['help wanted'], remove: ['help wanted', 'good first issue'] },
+    { command: '/good-first-issue', add: ['good first issue', 'help wanted'], remove: ['good first issue'] },
+];
+/**
+ * addFixedLabels labels the issue with the command's fixed labels
+ *
+ * @param context - the github actions event context
+ * @param cmd - the command definition
+ */
+async function addFixedLabels(context, cmd) {
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    await labelIssue(octokit, context, fixed_requireIssueNumber(context), cmd.add);
+}
+/**
+ * removeFixedLabels removes the command's fixed labels that are on the issue
+ *
+ * @param context - the github actions event context
+ * @param cmd - the command definition
+ */
+async function removeFixedLabels(context, cmd) {
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    const issueNumber = fixed_requireIssueNumber(context);
+    let currentLabels = [];
+    try {
+        currentLabels = await getCurrentLabels(octokit, context, issueNumber);
+        core_debug(`${cmd.command.slice(1)}: found labels for issue ${currentLabels}`);
+    }
+    catch (e) {
+        throw new Error(`could not get labels from issue: ${e}`);
+    }
+    const present = currentLabels.filter(label => cmd.remove.some(requested => sameLabel(requested, label)));
+    if (present.length === 0) {
+        core_debug(`${cmd.command.slice(1)}: none of ${cmd.remove} are on the issue`);
+        return;
+    }
+    await removeLabels(octokit, context, issueNumber, present);
+}
+function fixed_requireIssueNumber(context) {
+    const issueNumber = context.payload.issue?.number;
+    if (issueNumber === undefined) {
+        throw new Error(`github context payload missing issue number: ${context.payload}`);
+    }
+    return issueNumber;
 }
 
 ;// CONCATENATED MODULE: ./lib/labels/hold.js
@@ -44556,147 +44698,6 @@ async function refuse(octokit, context, issueNumber, msg, cause = new Error(msg)
         error(`Could not comment with an auth error: ${commentE}`);
     }
     throw cause;
-}
-
-;// CONCATENATED MODULE: ./lib/labels/prefixed.js
-
-
-
-
-const prefixedLabelCommands = [
-    { command: '/area', prefix: 'area', allowlistKey: 'area' },
-    { command: '/kind', prefix: 'kind', allowlistKey: 'kind' },
-    { command: '/priority', prefix: 'priority', allowlistKey: 'priority', exclusive: true },
-    { command: '/label', prefix: '', allowlistKey: 'labels' },
-    { command: '/lifecycle', prefix: 'lifecycle', allowlistKey: 'lifecycle', exclusive: true, defaultValues: ['frozen', 'stale', 'rotten'] },
-    { command: '/stage', prefix: 'stage', allowlistKey: 'stage', exclusive: true, defaultValues: ['alpha', 'beta', 'stable'] },
-    { command: '/status', prefix: 'status', allowlistKey: 'status', exclusive: true, defaultValues: ['approved-for-milestone', 'in-progress', 'in-review'] },
-];
-// a .prowlabels.yaml key usable as a slash command: lower-case letters, digits and dashes
-const labelCommandName = /^[a-z][a-z0-9-]*$/;
-/**
- * dynamicPrefixedCommand builds the command for an arbitrary .prowlabels.yaml
- * key so that `/<key> value` labels the issue with '<key>/value'
- *
- * @param name - the top level key, ex: 'level'
- */
-function dynamicPrefixedCommand(name) {
-    return { command: `/${name}`, prefix: name, allowlistKey: name };
-}
-/**
- * removeCommandFor returns the Prow-style removal spelling of a label command
- * Ex: '/kind' -> '/remove-kind'
- *
- * @param command - the add form of the command
- */
-function removeCommandFor(command) {
-    return `/remove-${command.slice(1)}`;
-}
-/**
- * addPrefixedLabels labels the issue with '<prefix>/<value>' for every value
- * that is both in the comment and in the .prowlabels.yaml allowlist.
- * When the command is exclusive, existing '<prefix>/*' labels that were not
- * requested are removed first.
- *
- * @param context - the github actions event context
- * @param cmd - the command definition
- */
-async function addPrefixedLabels(context, cmd) {
-    const token = getInput('github-token', { required: true });
-    const octokit = newOctokit(token);
-    const issueNumber = prefixed_requireIssueNumber(context);
-    const commentBody = context.payload.comment?.body;
-    const section = await allowlistFor(octokit, context, cmd);
-    const labels = requestedLabels(cmd, cmd.command, commentBody, section.values);
-    if (section.exclusive) {
-        const currentLabels = await currentIssueLabels(octokit, context, issueNumber, cmd.command);
-        const stale = currentLabels.filter((label) => {
-            return label.toLowerCase().startsWith(`${cmd.prefix.toLowerCase()}/`)
-                && !labels.some(requested => sameLabel(requested, label));
-        });
-        if (stale.length > 0) {
-            await removeLabels(octokit, context, issueNumber, stale);
-        }
-    }
-    await labelIssue(octokit, context, issueNumber, labels);
-}
-/**
- * removePrefixedLabels removes '<prefix>/<value>' for every value in the
- * /remove-<command> line that is in the .prowlabels.yaml allowlist and
- * currently on the issue. Restricting removal to the allowlist keeps
- * anyone from stripping protected labels such as lgtm, approved or hold.
- *
- * @param context - the github actions event context
- * @param cmd - the command definition
- */
-async function removePrefixedLabels(context, cmd) {
-    const token = getInput('github-token', { required: true });
-    const octokit = newOctokit(token);
-    const issueNumber = prefixed_requireIssueNumber(context);
-    const commentBody = context.payload.comment?.body;
-    const command = removeCommandFor(cmd.command);
-    const section = await allowlistFor(octokit, context, cmd);
-    const labels = requestedLabels(cmd, command, commentBody, section.values);
-    const currentLabels = await currentIssueLabels(octokit, context, issueNumber, command);
-    const present = currentLabels.filter(label => labels.some(requested => sameLabel(requested, label)));
-    if (present.length === 0) {
-        core_debug(`${command.slice(1)}: none of ${labels} are on the issue`);
-        return;
-    }
-    await removeLabels(octokit, context, issueNumber, present);
-}
-function prefixed_requireIssueNumber(context) {
-    const issueNumber = context.payload.issue?.number;
-    if (issueNumber === undefined) {
-        throw new Error(`github context payload missing issue number: ${context.payload}`);
-    }
-    return issueNumber;
-}
-// the yaml section wins over the built-in defaults; a yaml `exclusive` wins over the registry
-async function allowlistFor(octokit, context, cmd) {
-    const key = cmd.allowlistKey;
-    try {
-        const section = (await getLabelConfig(octokit, context))[key];
-        if (section) {
-            core_debug(`${key}: found labels ${section.values}`);
-            return { values: section.values, exclusive: section.exclusive ?? cmd.exclusive ?? false };
-        }
-        if (cmd.defaultValues) {
-            core_debug(`${key}: using built-in labels ${cmd.defaultValues}`);
-            return { values: cmd.defaultValues, exclusive: cmd.exclusive ?? false };
-        }
-        throw new Error(`${key}: yaml malformed, expected '${key}' top level key`);
-    }
-    catch (e) {
-        throw new Error(`could not get labels from yaml: ${e}`);
-    }
-}
-function requestedLabels(cmd, command, commentBody, allowed) {
-    const args = getCommandArgs(command, commentBody);
-    const canonical = new Map(allowed.map(value => [value.toLowerCase(), value]));
-    const values = args
-        .map(arg => canonical.get(arg.toLowerCase()))
-        .filter((value) => value !== undefined);
-    const labels = addPrefix(cmd.prefix, [...new Set(values)]);
-    // no arguments after command provided
-    if (labels.length === 0) {
-        throw new Error(`${command.slice(1)}: command args missing from body`);
-    }
-    return labels;
-}
-// GitHub label names are case-insensitive, as are Prow's comparisons
-function sameLabel(a, b) {
-    return a.toLowerCase() === b.toLowerCase();
-}
-async function currentIssueLabels(octokit, context, issueNumber, command) {
-    try {
-        const currentLabels = await getCurrentLabels(octokit, context, issueNumber);
-        core_debug(`${command.slice(1)}: found labels for issue ${currentLabels}`);
-        return currentLabels;
-    }
-    catch (e) {
-        throw new Error(`could not get labels from issue: ${e}`);
-    }
 }
 
 ;// CONCATENATED MODULE: ./lib/labels/remove.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -43545,7 +43545,13 @@ async function sendLabels(octokit, context, prNum, labels) {
  * @param context - the github context of the current action event
  */
 async function handleCronJobs(context = github_context) {
-    const runConfig = getInput('jobs', { required: false }).split(' ');
+    const runConfig = getInput('jobs', { required: false })
+        .split(/\s+/)
+        .filter(command => command !== '')
+        .map(command => command.toLowerCase());
+    if (runConfig.length === 0) {
+        runConfig.push('');
+    }
     await Promise.all(runConfig.map(async (command) => {
         switch (command) {
             case 'pr-labeler':
@@ -45726,7 +45732,13 @@ async function onPrLgtm(context) {
  * @param context - the github context of the current action event
  */
 async function handlePullReq(context = github_context) {
-    const runConfig = getInput('jobs', { required: false }).split(' ');
+    const runConfig = getInput('jobs', { required: false })
+        .split(/\s+/)
+        .filter(command => command !== '')
+        .map(command => command.toLowerCase());
+    if (runConfig.length === 0) {
+        runConfig.push('');
+    }
     await Promise.all(runConfig.map(async (command) => {
         core_debug(`${context}`);
         switch (command) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,6 @@ These docs describe `main`. Features added since the latest release (`v2.0.0`) s
 - A command must start a line of the comment; leading whitespace is allowed. A command mentioned mid-sentence is ignored.
 - Commands and their keywords (`cancel`, `clear`, `not-planned`) are case-insensitive: `/LGTM cancel` works.
 - **Label values** are matched case-insensitively against `.prowlabels.yaml` (or `.prowlabels.yml`, see [labeling](./labeling.md)) and applied with the casing written in the file: `/kind Bug` adds `kind/bug`.
-- `/lock` reasons are the exception: they are **case-sensitive**, and an unknown reason locks with no reason.
 - Commands inside Markdown code (fenced ``` / ~~~ blocks, indented code, inline `code`) and blockquotes are ignored.
 - When a command appears on several lines of one comment every line is applied (`/kind bug` and `/kind cleanup` add both labels), except `/milestone` and `/retitle` where the last line wins.
 - A `cancel` on any line wins over a plain `/lgtm`, `/hold` or `/approve`.
@@ -28,7 +27,7 @@ Commands | Policy | Description
 `/close` | Collaborators **or the issue/PR author** | closes the issue / PR
 `/close not-planned` | Collaborators **or the issue/PR author** | closes the issue / PR with the `not planned` state reason
 `/reopen` | Collaborators **or the issue/PR author** | reopens a closed issue / PR
-`/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason. Reasons are **case-sensitive**; an unknown reason locks with no reason
+`/lock [resolved / off-topic / too-heated / spam]` | Collaborators | locks the issue / PR with the specified reason (case-insensitive; an unknown reason fails the run without locking)
 `/milestone milestone-name` | Collaborators | Adds issue / PR to an existing milestone. With no title the run fails. An unknown title fails the run with the list of available milestones
 `/milestone clear` | Collaborators | Removes the issue / PR from its milestone
 `/retitle some new title` | Collaborators | Renames the issue / PR. With no title, nothing happens

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -1,7 +1,7 @@
 # Cron jobs
 
 The following jobs are supported through [cron Github workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).
-The `jobs` input is space delimited on a single line (`jobs: lgtm`); multi-line `jobs:` blocks do not work.
+The `jobs` input is space or newline delimited and case-insensitive (`jobs: lgtm`).
 Both jobs page through the repository's pull requests, following pages until one comes back empty, and skip locked and closed PRs.
 
 Jobs | Description

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -104,15 +104,16 @@ The file itself must still exist, as it does for every other label command.
 
 `/help` and `/good-first-issue` mirror Prow's help plugin and use GitHub's default
 label names, which contain spaces and therefore cannot be listed in
-`.prowlabels.yaml`. They are fixed and do not read the file at all:
+`.prowlabels.yaml`. They are fixed and do not read the file at all. Removal
+matches labels case-insensitively and deletes them with the casing on the issue:
 
 Command | Adds | `/remove-` form removes
 --- | --- | ---
 `/help` | `help wanted` | `help wanted`, `good first issue`
 `/good-first-issue` | `good first issue`, `help wanted` | `good first issue`
 
-Removal matches label names **case-sensitively**, unlike the prefixed label
-commands: `/remove-help` does not remove a label spelled `Help Wanted`.
+Removal matches label names case-insensitively, like the prefixed label
+commands: `/remove-help` removes a label spelled `Help Wanted` as it appears on the issue.
 
 ## Removing labels
 

--- a/docs/pr-jobs.md
+++ b/docs/pr-jobs.md
@@ -1,5 +1,7 @@
 # Pull Request Jobs
 
+The `jobs` input is space or newline delimited and case-insensitive.
+
 Jobs | Description
 --- | ---
 `lgtm` | Removes the `lgtm` label (if present) when the PR is updated, so updated code must be reviewed again before [automatic merging](./automatic-merging.md).

--- a/src/cronJobs/handleCronJob.ts
+++ b/src/cronJobs/handleCronJob.ts
@@ -14,7 +14,15 @@ import { cronLabelPr } from './prLabeler'
  * @param context - the github context of the current action event
  */
 export async function handleCronJobs(context: Context = github.context): Promise<void> {
-  const runConfig = core.getInput('jobs', { required: false }).split(' ')
+  const runConfig = core
+    .getInput('jobs', { required: false })
+    .split(/\s+/)
+    .filter(command => command !== '')
+    .map(command => command.toLowerCase())
+
+  if (runConfig.length === 0) {
+    runConfig.push('')
+  }
 
   await Promise.all(
     runConfig.map(async (command) => {

--- a/src/issueComment/lock.ts
+++ b/src/issueComment/lock.ts
@@ -6,6 +6,15 @@ import { checkCollaborator } from '../utils/auth'
 import { getCommandArgs } from '../utils/command'
 import { newOctokit } from '../utils/octokit'
 
+type LockReason = 'off-topic' | 'too heated' | 'resolved' | 'spam'
+
+const lockReasons: Record<string, LockReason> = {
+  'resolved': 'resolved',
+  'off-topic': 'off-topic',
+  'too-heated': 'too heated',
+  'spam': 'spam',
+}
+
 /**
  * /lock will lock the issue / PR.
  * No more comments will be permitted
@@ -39,82 +48,24 @@ export async function lock(context: Context = github.context): Promise<void> {
   }
 
   if (isAuthUser) {
+    let lockReason: LockReason | undefined
     if (commentArgs.length > 0) {
-      switch (commentArgs[0]) {
-        case 'resolved':
-          try {
-            await octokit.issues.lock({
-              ...context.repo,
-              issue_number: issueNumber,
-            })
-          }
-          catch (e) {
-            throw new Error(`could not lock issue: ${e}`)
-          }
-          break
-
-        case 'off-topic':
-          try {
-            await octokit.issues.lock({
-              ...context.repo,
-              issue_number: issueNumber,
-              lock_reason: 'off-topic',
-            })
-          }
-          catch (e) {
-            throw new Error(`could not lock issue: ${e}`)
-          }
-          break
-
-        case 'too-heated':
-          try {
-            await octokit.issues.lock({
-              ...context.repo,
-              issue_number: issueNumber,
-              lock_reason: 'too heated',
-            })
-          }
-          catch (e) {
-            throw new Error(`could not lock issue: ${e}`)
-          }
-          break
-
-        case 'spam':
-          try {
-            await octokit.issues.lock({
-              ...context.repo,
-              issue_number: issueNumber,
-              lock_reason: 'spam',
-            })
-          }
-          catch (e) {
-            throw new Error(`could not lock issue: ${e}`)
-          }
-          break
-
-        default:
-          try {
-            await octokit.issues.lock({
-              ...context.repo,
-              issue_number: issueNumber,
-            })
-          }
-          catch (e) {
-            throw new Error(`could not lock issue: ${e}`)
-          }
-          break
+      const arg = commentArgs[0].toLowerCase()
+      lockReason = lockReasons[arg]
+      if (lockReason === undefined) {
+        throw new Error(`/lock: unknown reason "${commentArgs[0]}". Use resolved, off-topic, too-heated or spam`)
       }
     }
-    else {
-      try {
-        await octokit.issues.lock({
-          ...context.repo,
-          issue_number: issueNumber,
-        })
-      }
-      catch (e) {
-        throw new Error(`could not lock issue: ${e}`)
-      }
+
+    try {
+      await octokit.issues.lock({
+        ...context.repo,
+        issue_number: issueNumber,
+        ...(lockReason !== undefined ? { lock_reason: lockReason } : {}),
+      })
+    }
+    catch (e) {
+      throw new Error(`could not lock issue: ${e}`)
     }
   }
   else {

--- a/src/labels/fixed.ts
+++ b/src/labels/fixed.ts
@@ -3,6 +3,7 @@ import * as core from '@actions/core'
 
 import { getCurrentLabels, labelIssue, removeLabels } from '../utils/labeling'
 import { newOctokit } from '../utils/octokit'
+import { sameLabel } from './prefixed'
 
 export interface FixedLabelCommand {
   /** the slash command, ex: '/help' */
@@ -52,7 +53,7 @@ export async function removeFixedLabels(context: Context, cmd: FixedLabelCommand
     throw new Error(`could not get labels from issue: ${e}`)
   }
 
-  const present = cmd.remove.filter(label => currentLabels.includes(label))
+  const present = currentLabels.filter(label => cmd.remove.some(requested => sameLabel(requested, label)))
 
   if (present.length === 0) {
     core.debug(`${cmd.command.slice(1)}: none of ${cmd.remove} are on the issue`)

--- a/src/labels/prefixed.ts
+++ b/src/labels/prefixed.ts
@@ -181,7 +181,7 @@ function requestedLabels(
 }
 
 // GitHub label names are case-insensitive, as are Prow's comparisons
-function sameLabel(a: string, b: string): boolean {
+export function sameLabel(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase()
 }
 

--- a/src/pullReq/handlePullReq.ts
+++ b/src/pullReq/handlePullReq.ts
@@ -12,7 +12,15 @@ import { onPrLgtm } from './onPrLgtm'
  * @param context - the github context of the current action event
  */
 export async function handlePullReq(context: Context = github.context): Promise<void> {
-  const runConfig = core.getInput('jobs', { required: false }).split(' ')
+  const runConfig = core
+    .getInput('jobs', { required: false })
+    .split(/\s+/)
+    .filter(command => command !== '')
+    .map(command => command.toLowerCase())
+
+  if (runConfig.length === 0) {
+    runConfig.push('')
+  }
 
   await Promise.all(
     runConfig.map(async (command) => {


### PR DESCRIPTION
# Description

Three small consistency bugs surfaced by the docs audit in #140, fixed together. Each was reproduced failing-test-first.

## `fix(lock): case-insensitive reasons, pass resolved, reject unknown reasons`
- `/lock` was the **only** command whose argument was matched case-sensitively; `/lock Spam` fell through and locked with no reason. Reasons are now lowercased like every other keyword.
- **Real bug:** the `resolved` branch called `issues.lock` without `lock_reason`, even though GitHub accepts `"resolved"` (it's in the Octokit type). `/lock resolved` now actually records the reason.
- An **unknown reason now fails** (`/lock: unknown reason "bogus". Use resolved, off-topic, too-heated or spam`) instead of silently locking — consistent with `/milestone` on an unknown title.
- Four near-identical `try { issues.lock }` blocks collapsed into one call with a computed reason; collaborator gating and the `could not lock issue:` wrapping unchanged.

## `fix: accept whitespace-delimited jobs input`
`jobs:` was split on a single space, so a multi-line `jobs: |` block produced an empty token and failed with "please provide a list…" — while `action.yml` told users to put jobs on their own line. Both the cron and PR-job handlers now split on `/\s+/`, drop empties and lowercase, exactly as `prow-commands` already did. `action.yml` description → "Space or newline delimited."

## `fix(labels): remove help labels case-insensitively`
`/remove-help` compared label names with exact `includes`; an issue labelled `Help Wanted` was never cleaned up. Now uses the same `sameLabel` comparison as prefixed labels and deletes the label **as spelled on the issue**.

## Assertions changed (1)
`lock.test.ts` "…reason resolved" previously asserted that **no** `lock_reason` was sent (pinning the bug); it now asserts `{ lock_reason: 'resolved' }`.

## Testing
- **459 → 469 tests**; coverage 92.8 / 92.9 br / 98.9 fn
- Red→green for all three (details in commit messages); hermetic under a simulated Actions env; `dist/` byte-identical across repeated packs

> Note: touches `docs/commands.md`, `cron-jobs.md`, `pr-jobs.md`, `labeling.md` and `action.yml`, which #140 also edits. Whichever merges second needs a rebase — I'll handle it.
