### PR TITLE
fix: protect lgtm/hold/approved from /label; fail the lgtm cron when a merge fails

### DIFF
--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -455,12 +455,12 @@ describe('dist/index.js', () => {
   })
 
   describe('schedule lgtm job', () => {
-    function routePulls(pr: unknown) {
+    function routePulls(pr: unknown, merge: { status: number, body: unknown } = { status: 200, body: { merged: true } }) {
       gh.route('GET', new RegExp(`^${repo}/pulls\\?`), (req) => {
         const page = new URL(req.path, gh.url).searchParams.get('page')
         return { status: 200, body: page === '1' ? [pr] : [] }
       })
-      gh.route('PUT', `${repo}/pulls/2/merge`, { status: 200, body: { merged: true } })
+      gh.route('PUT', `${repo}/pulls/2/merge`, merge)
     }
 
     function runCron() {
@@ -513,6 +513,22 @@ describe('dist/index.js', () => {
       expect(gh.requestsMatching('PUT', /./)).toEqual([])
       expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
         `GET ${repo}/pulls?state=open&page=1`,
+        `GET ${repo}/pulls?state=open&page=2`,
+      ])
+    })
+
+    it('fails the run when a merge is refused', async () => {
+      routePulls(openPr(['lgtm']), { status: 405, body: { message: 'Pull Request is not mergeable' } })
+
+      const result = await runCron()
+
+      expect(result.status, result.stdout).toBe(1)
+      expect(result.errors.some(e => e.includes('could not merge pr #2'))).toBe(true)
+      expect(result.errors.some(e => e.includes('1 pull request(s) could not be merged: #2 (Pull Request is not mergeable)'))).toBe(true)
+      expect(gh.requestsMatching('PUT', /\/pulls\/2\/merge$/)).toHaveLength(1)
+      expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+        `GET ${repo}/pulls?state=open&page=1`,
+        `PUT ${repo}/pulls/2/merge`,
         `GET ${repo}/pulls?state=open&page=2`,
       ])
     })

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -136,6 +136,28 @@ describe('dist/index.js', () => {
     ])
   })
 
+  it('issue_comment /remove-label refuses lgtm even when .prowlabels.yaml lists it', async () => {
+    const listsLgtm = structuredClone(labelFileContents)
+    listsLgtm.content = Buffer.from('labels:\n  - lgtm\n  - documentation\n').toString('base64')
+    gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: listsLgtm })
+    gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'lgtm' }] } })
+    gh.route('DELETE', `${repo}/issues/1/labels/lgtm`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/remove-label lgtm'),
+      inputs: { ...token, 'prow-commands': '/label' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(1)
+    expect(result.errors.some(e => e.includes('managed by its own command'))).toBe(true)
+    expect(gh.requestsMatching('DELETE', /./)).toEqual([])
+    expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      `GET ${repo}/contents/.prowlabels.yaml`,
+    ])
+  })
+
   it('issue_comment /level uses a mapping-form yaml key as an exclusive label command', async () => {
     gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: labelFileContents })
     gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'level/sandbox' }] } })

--- a/__tests__/cronJobTest/lgtm.test.ts
+++ b/__tests__/cronJobTest/lgtm.test.ts
@@ -1,6 +1,7 @@
+import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
 import listPullReqs from '../fixtures/pullReq/pullReqListPulls.json'
@@ -171,5 +172,96 @@ describe('cronLgtm', () => {
 
     await expect(handleCronJobs(context)).resolves.not.toThrow()
     await expect(observeReq.notCalled()).resolves.toBe('not called')
+  })
+
+  function lgtmPr(number: number) {
+    const pr = structuredClone(listPullReqs[0])
+    pr.number = number
+    pr.labels = [{ ...pr.labels[0], name: 'lgtm' }]
+    return pr
+  }
+
+  function routePulls(prs: unknown[]) {
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls`,
+        ({ request }) => {
+          const page = new URL(request.url).searchParams.get('page')
+          return utils.mockResponse(200, page === '1' ? prs : [])({ request })
+        },
+      ),
+    )
+  }
+
+  it('does not fail the run when the merge succeeds', async () => {
+    utils.setupJobsEnv('lgtm')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    routePulls([lgtmPr(2)])
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/2/merge`,
+        utils.mockResponse(200, { merged: true }, observeReq),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const error = vi.spyOn(core, 'error').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    await expect(observeReq.called()).resolves.toBe('called')
+    expect(setFailed).not.toHaveBeenCalled()
+    expect(error).not.toHaveBeenCalled()
+  })
+
+  it('attempts every PR and fails the run listing the merge that failed', async () => {
+    utils.setupJobsEnv('lgtm')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    routePulls([lgtmPr(3), lgtmPr(4)])
+
+    const observeFirst = new utils.ObserveRequest()
+    const observeSecond = new utils.ObserveRequest()
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/3/merge`,
+        utils.mockResponse(405, { message: 'Pull Request is not mergeable' }, observeFirst),
+      ),
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/4/merge`,
+        utils.mockResponse(200, { merged: true }, observeSecond),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const error = vi.spyOn(core, 'error').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    await expect(observeFirst.called()).resolves.toBe('called')
+    await expect(observeSecond.called()).resolves.toBe('called')
+
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('could not merge pr #3'))
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('1 pull request(s) could not be merged'))
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('#3'))
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('not mergeable'))
+    expect(setFailed).not.toHaveBeenCalledWith(expect.stringContaining('#4'))
+  })
+
+  it('reports a 409 base branch change in the failure message', async () => {
+    utils.setupJobsEnv('lgtm')
+    const context = new utils.MockContext(pullReqOpenedEvent)
+    routePulls([lgtmPr(5)])
+
+    server.use(
+      http.put(
+        `${utils.api}/repos/Codertocat/Hello-World/pulls/5/merge`,
+        utils.mockResponse(409, { message: 'Base branch was modified. Review and try the merge again.' }),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    vi.spyOn(core, 'error').mockImplementation(() => {})
+    await expect(handleCronJobs(context)).resolves.not.toThrow()
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('#5 (Base branch was modified'))
   })
 })

--- a/__tests__/label/label.test.ts
+++ b/__tests__/label/label.test.ts
@@ -5,6 +5,7 @@ import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
+import { isProtectedLabel } from '../../src/labels/prefixed'
 import issuePayload from '../fixtures/issues/issue.json'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
@@ -27,6 +28,116 @@ function issueWithLabels(...names: string[]) {
   }
   return payload
 }
+
+// a repo that lists the protected labels under `labels:` is not itself an error
+const withProtected = structuredClone(labelFileContents)
+withProtected.content = Buffer.from(
+  'labels:\n  - documentation\n  - lgtm\n  - hold\n  - approved\n  - do-not-merge/work-in-progress\n',
+).toString('base64')
+
+describe('isProtectedLabel', () => {
+  it.each(['lgtm', 'hold', 'approved', 'LGTM', 'Hold', 'do-not-merge/work-in-progress', 'DO-NOT-MERGE/hold'])(
+    'protects %s',
+    (label) => {
+      expect(isProtectedLabel(label)).toBe(true)
+    },
+  )
+
+  it.each(['documentation', 'kind/lgtm', 'lgtm-please', 'do-not-merge', 'holdover'])(
+    'does not protect %s',
+    (label) => {
+      expect(isProtectedLabel(label)).toBe(false)
+    },
+  )
+})
+
+describe('protected labels', () => {
+  beforeEach(() => {
+    utils.setupActionsEnv('/label')
+  })
+
+  it.each(['/label lgtm', '/label do-not-merge/work-in-progress', '/label documentation lgtm'])(
+    'refuses "%s" without adding any label',
+    async (body) => {
+      issueCommentEvent.comment.body = body
+      const commentContext = new utils.MockContext(issueCommentEvent)
+
+      const observePost = new utils.ObserveRequest()
+      server.use(
+        http.post(
+          `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+          utils.mockResponse(200, null, observePost),
+        ),
+        http.get(
+          `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+          utils.mockResponse(200, withProtected),
+        ),
+      )
+
+      const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+      await handleIssueComment(commentContext)
+      await expect(observePost.notCalled()).resolves.toBe('not called')
+      expect(setFailed).toHaveBeenCalledTimes(1)
+      expect(setFailed).toHaveBeenCalledWith(
+        expect.stringContaining('managed by its own command and cannot be changed with /label'),
+      )
+    },
+  )
+
+  it.each([
+    ['/remove-label hold', 'hold'],
+    ['/remove-label LGTM', 'lgtm'],
+  ])('refuses "%s" without removing any label', async (body, onIssue) => {
+    issueCommentEvent.comment.body = body
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observeDelete = new utils.ObserveRequest()
+    server.use(
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/${onIssue}`,
+        utils.mockResponse(200, null, observeDelete),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, issueWithLabels(onIssue)),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, withProtected),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await expect(observeDelete.notCalled()).resolves.toBe('not called')
+    expect(setFailed).toHaveBeenCalledWith(
+      expect.stringContaining(`remove-label: ${onIssue} is managed by its own command and cannot be changed with /remove-label`),
+    )
+  })
+
+  it('still adds a plain label listed next to protected ones', async () => {
+    issueCommentEvent.comment.body = '/label documentation'
+    const commentContext = new utils.MockContext(issueCommentEvent)
+
+    const observePost = new utils.ObserveRequest()
+    server.use(
+      http.post(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
+        utils.mockResponse(200, null, observePost),
+      ),
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
+        utils.mockResponse(200, withProtected),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await handleIssueComment(commentContext)
+    await observePost.called()
+    expect(await observePost.body()).toEqual({ labels: ['documentation'] })
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+})
 
 describe('label', () => {
   beforeEach(() => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -37254,16 +37254,18 @@ function newOctokit(token) {
 
 
 
-let jobsDone = 0;
 /**
  * Inspired by https://github.com/actions/stale
  * this will recurse through the pages of PRs for a repo
- * and attempt to merge them if they have the "lgtm" label
+ * and attempt to merge them if they have the "lgtm" label.
+ * Every PR is attempted; once all pages are processed the run fails
+ * if any merge was refused, listing the affected PRs.
  *
  * @param currentPage - the page to return from the github api
  * @param context - The github actions event context
+ * @param progress - merges done and failures collected on earlier pages
  */
-async function cronLgtm(currentPage, context) {
+async function cronLgtm(currentPage, context, progress = { jobsDone: 0, failures: [] }) {
     info(`starting lgtm merger page: ${currentPage}`);
     const token = getInput('github-token', { required: true });
     const octokit = newOctokit(token);
@@ -37277,7 +37279,11 @@ async function cronLgtm(currentPage, context) {
     }
     if (prs.length <= 0) {
         // All done!
-        return jobsDone;
+        if (progress.failures.length > 0) {
+            const list = progress.failures.map(f => `#${f.number} (${f.message})`).join(', ');
+            throw new Error(`${progress.failures.length} pull request(s) could not be merged: ${list}`);
+        }
+        return progress.jobsDone;
     }
     const results = await Promise.all(prs.map(async (pr) => {
         info(`processing pr: ${pr.number}`);
@@ -37288,8 +37294,9 @@ async function cronLgtm(currentPage, context) {
             return;
         }
         try {
-            await tryMergePr(pr, octokit, context);
-            jobsDone++;
+            if (await tryMergePr(pr, octokit, context, progress.failures)) {
+                progress.jobsDone++;
+            }
         }
         catch (error) {
             return error;
@@ -37301,7 +37308,7 @@ async function cronLgtm(currentPage, context) {
         }
     }
     // Recurse, continue to next page
-    return await cronLgtm(currentPage + 1, context);
+    return await cronLgtm(currentPage + 1, context, progress);
 }
 /**
  * grabs pulls from github in baches of 100
@@ -37321,45 +37328,45 @@ async function getOpenPrs(octokit, context = github_context, page) {
     return prResults.data;
 }
 /**
- * Attempts to merge a PR if it is mergable and has the lgtm label
+ * Attempts to merge a PR if it has the lgtm label and not the hold label.
+ * A refused merge is logged as an error annotation and recorded in
+ * failures instead of aborting the run.
  *
  * @param pr - the PR to try and merge
  * @param octokit - a hydrated github api client
  * @param context - the github actions event context
+ * @param failures - collects PRs whose merge the api refused
+ * @returns whether the PR was merged
  */
-async function tryMergePr(pr, octokit, context = github_context) {
+async function tryMergePr(pr, octokit, context = github_context, failures) {
     const method = getInput('merge-method', { required: false });
-    // if pr has label 'lgtm', attempt to merge
-    // but not if it has the 'hold' label
-    if (pr.labels.map(e => e.name).includes('lgtm')
-        && !pr.labels.map(e => e.name).includes('hold')) {
-        try {
-            switch (method) {
-                case 'squash':
-                    await octokit.pulls.merge({
-                        ...context.repo,
-                        pull_number: pr.number,
-                        merge_method: 'squash',
-                    });
-                    break;
-                case 'rebase':
-                    await octokit.pulls.merge({
-                        ...context.repo,
-                        pull_number: pr.number,
-                        merge_method: 'rebase',
-                    });
-                    break;
-                default:
-                    await octokit.pulls.merge({
-                        ...context.repo,
-                        pull_number: pr.number,
-                        merge_method: 'merge',
-                    });
-            }
-        }
-        catch (e) {
-            core_debug(`could not merge pr ${pr.number}: ${e}`);
-        }
+    const names = pr.labels.map(e => e.name);
+    if (!names.includes('lgtm') || names.includes('hold')) {
+        return false;
+    }
+    try {
+        await octokit.pulls.merge({
+            ...context.repo,
+            pull_number: pr.number,
+            merge_method: mergeMethod(method),
+        });
+        return true;
+    }
+    catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        error(`could not merge pr #${pr.number}: ${message}`);
+        failures.push({ number: pr.number, message });
+        return false;
+    }
+}
+// an unknown merge-method input falls back to 'merge'
+function mergeMethod(input) {
+    switch (input) {
+        case 'squash':
+        case 'rebase':
+            return input;
+        default:
+            return 'merge';
     }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -41374,6 +41374,13 @@ const prefixedLabelCommands = [
 ];
 // a .prowlabels.yaml key usable as a slash command: lower-case letters, digits and dashes
 const labelCommandName = /^[a-z][a-z0-9-]*$/;
+// labels with dedicated, authorization-gated commands; never reachable through /label
+const protectedLabels = ['lgtm', 'hold', 'approved'];
+const protectedPrefixes = ['do-not-merge/'];
+function isProtectedLabel(label) {
+    const lower = label.toLowerCase();
+    return protectedLabels.includes(lower) || protectedPrefixes.some(prefix => lower.startsWith(prefix));
+}
 /**
  * dynamicPrefixedCommand builds the command for an arbitrary .prowlabels.yaml
  * key so that `/<key> value` labels the issue with '<key>/value'
@@ -41423,8 +41430,8 @@ async function addPrefixedLabels(context, cmd) {
 /**
  * removePrefixedLabels removes '<prefix>/<value>' for every value in the
  * /remove-<command> line that is in the .prowlabels.yaml allowlist and
- * currently on the issue. Restricting removal to the allowlist keeps
- * anyone from stripping protected labels such as lgtm, approved or hold.
+ * currently on the issue. Labels owned by other commands (lgtm, hold,
+ * approved, do-not-merge/*) are refused even when the allowlist names them.
  *
  * @param context - the github actions event context
  * @param cmd - the command definition
@@ -41481,6 +41488,12 @@ function requestedLabels(cmd, command, commentBody, allowed) {
     // no arguments after command provided
     if (labels.length === 0) {
         throw new Error(`${command.slice(1)}: command args missing from body`);
+    }
+    if (cmd.prefix === '') {
+        const offender = labels.find(isProtectedLabel);
+        if (offender !== undefined) {
+            throw new Error(`${command.slice(1)}: ${offender} is managed by its own command and cannot be changed with ${command}`);
+        }
     }
     return labels;
 }

--- a/docs/automatic-merging.md
+++ b/docs/automatic-merging.md
@@ -30,7 +30,10 @@ This Github workflow will check every hour
 for PRs with the `lgtm` label and will attempt to automatically merge them.
 If the `hold` label is present, it will block automatic merging.
 Locked and closed PRs are skipped. An unknown `merge-method` falls back to `merge`.
-A merge failure is logged at debug level and does **not** fail the run.
+Every eligible PR is attempted, so one un-mergeable PR does not stop the others.
+Each failed merge is logged as an error annotation (`could not merge pr #<n>: <reason>`);
+once all pages are processed the run fails if any merge failed, listing the PRs:
+`2 pull request(s) could not be merged: #1 (Pull Request is not mergeable), #7 (...)`.
 
 The companion `lgtm` PR job removes the `lgtm` label from a PR that gets updated.
 This prevents any un-reviewed code from being automatically merged by the lgtm-merger mechanism.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,8 +47,8 @@ Label Commands | Policy | Description
 `/unhold`, `/remove-hold` | anyone | same as `/hold cancel`
 `/priority [label1 label2 ...]` | anyone | adds a priority/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md). Exclusive by default: replaces any existing `priority/*` labels
 `/remove-priority [label1 label2 ...]` | anyone | removes a priority/<> label(s) if it's defined in [the `.prowlabels.yaml` file](./labeling.md)
-`/label [label1 label2 ...]` | anyone | adds the label(s) verbatim if listed under `labels:` in [the `.prowlabels.yaml` file](./labeling.md). Label names containing spaces are not supported
-`/remove-label [label1 label2 ...]` | anyone | removes the label(s) if listed under `labels:` in [the `.prowlabels.yaml` file](./labeling.md)
+`/label [label1 label2 ...]` | anyone | adds the label(s) verbatim if listed under `labels:` in [the `.prowlabels.yaml` file](./labeling.md). Label names containing spaces are not supported. Refuses `lgtm`, `hold`, `approved` and `do-not-merge/*`
+`/remove-label [label1 label2 ...]` | anyone | removes the label(s) if listed under `labels:` in [the `.prowlabels.yaml` file](./labeling.md). Refuses `lgtm`, `hold`, `approved` and `do-not-merge/*`
 `/lifecycle [frozen / stale / rotten]` | anyone | adds the `lifecycle/<>` label and removes any other `lifecycle/*`. Values come from Prow and can be [overridden in `.prowlabels.yaml`](./labeling.md#lifecycle-stage-and-status-labels)
 `/remove-lifecycle [frozen / stale / rotten]` | anyone | removes the `lifecycle/<>` label
 `/stage [alpha / beta / stable]` | anyone | adds the `stage/<>` label and removes any other `stage/*`. Values come from Prow and can be [overridden in `.prowlabels.yaml`](./labeling.md#lifecycle-stage-and-status-labels)
@@ -63,7 +63,7 @@ Label Commands | Policy | Description
 `/remove-<key> [value1 value2 ...]` | anyone | removes `<key>/<value>` label(s) listed under `<key>` in [the `.prowlabels.yaml` file](./labeling.md)
 `/remove [label1 label2 ...]` | Collaborators | removes a specified label(s) on an issue / PR
 
-The `/remove-<key>` commands are enabled together with their base command and only remove values listed in `.prowlabels.yaml`, so anyone may use them without being able to strip `lgtm`, `hold` or `approved` — unless the repository lists those names under `labels:`, in which case `/remove-label` can remove them. Use `/remove` for arbitrary labels.
+The `/remove-<key>` commands are enabled together with their base command and only remove values listed in `.prowlabels.yaml`, so anyone may use them. `lgtm`, `hold`, `approved` and `do-not-merge/*` are always refused by `/label` and `/remove-label`, even when listed under `labels:`; the run fails with `<label> is managed by its own command`. Use `/lgtm`, `/hold` and `/approve` for those, and `/remove` for arbitrary labels.
 
 ## What happens when you are not authorized
 

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -73,6 +73,8 @@ labels:
 With the command `/label documentation`,
 the issue or PR will be labeled with `documentation` as written, with no prefix.
 Values are split on spaces, so label names containing spaces cannot be listed here.
+`lgtm`, `hold`, `approved` and `do-not-merge/*` are always refused by `/label` and
+`/remove-label`, even when listed here; use `/lgtm`, `/hold` and `/approve` instead.
 
 ## Lifecycle, stage and status labels
 

--- a/src/cronJobs/lgtm.ts
+++ b/src/cronJobs/lgtm.ts
@@ -5,8 +5,6 @@ import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { newOctokit } from '../utils/octokit'
 
-let jobsDone = 0
-
 type PullsListResponseDataType
   = RestEndpointMethodTypes['pulls']['list']['response']['data']
 
@@ -14,17 +12,31 @@ type PullsListResponseItem = PullsListResponseDataType extends (infer Item)[]
   ? Item
   : never
 
+interface MergeFailure {
+  number: number
+  message: string
+}
+
+interface LgtmProgress {
+  jobsDone: number
+  failures: MergeFailure[]
+}
+
 /**
  * Inspired by https://github.com/actions/stale
  * this will recurse through the pages of PRs for a repo
- * and attempt to merge them if they have the "lgtm" label
+ * and attempt to merge them if they have the "lgtm" label.
+ * Every PR is attempted; once all pages are processed the run fails
+ * if any merge was refused, listing the affected PRs.
  *
  * @param currentPage - the page to return from the github api
  * @param context - The github actions event context
+ * @param progress - merges done and failures collected on earlier pages
  */
 export async function cronLgtm(
   currentPage: number,
   context: Context,
+  progress: LgtmProgress = { jobsDone: 0, failures: [] },
 ): Promise<number> {
   core.info(`starting lgtm merger page: ${currentPage}`)
 
@@ -42,7 +54,11 @@ export async function cronLgtm(
 
   if (prs.length <= 0) {
     // All done!
-    return jobsDone
+    if (progress.failures.length > 0) {
+      const list = progress.failures.map(f => `#${f.number} (${f.message})`).join(', ')
+      throw new Error(`${progress.failures.length} pull request(s) could not be merged: ${list}`)
+    }
+    return progress.jobsDone
   }
 
   const results = await Promise.all(
@@ -57,8 +73,9 @@ export async function cronLgtm(
       }
 
       try {
-        await tryMergePr(pr, octokit, context)
-        jobsDone++
+        if (await tryMergePr(pr, octokit, context, progress.failures)) {
+          progress.jobsDone++
+        }
       }
       catch (error) {
         return error
@@ -73,7 +90,7 @@ export async function cronLgtm(
   }
 
   // Recurse, continue to next page
-  return await cronLgtm(currentPage + 1, context)
+  return await cronLgtm(currentPage + 1, context, progress)
 }
 
 /**
@@ -102,53 +119,52 @@ async function getOpenPrs(
 }
 
 /**
- * Attempts to merge a PR if it is mergable and has the lgtm label
+ * Attempts to merge a PR if it has the lgtm label and not the hold label.
+ * A refused merge is logged as an error annotation and recorded in
+ * failures instead of aborting the run.
  *
  * @param pr - the PR to try and merge
  * @param octokit - a hydrated github api client
  * @param context - the github actions event context
+ * @param failures - collects PRs whose merge the api refused
+ * @returns whether the PR was merged
  */
 async function tryMergePr(
   pr: PullsListResponseItem,
   octokit: Octokit,
   context: Context = github.context,
-): Promise<void> {
+  failures: MergeFailure[],
+): Promise<boolean> {
   const method = core.getInput('merge-method', { required: false })
 
-  // if pr has label 'lgtm', attempt to merge
-  // but not if it has the 'hold' label
-  if (
-    pr.labels.map(e => e.name).includes('lgtm')
-    && !pr.labels.map(e => e.name).includes('hold')
-  ) {
-    try {
-      switch (method) {
-        case 'squash':
-          await octokit.pulls.merge({
-            ...context.repo,
-            pull_number: pr.number,
-            merge_method: 'squash',
-          })
-          break
+  const names = pr.labels.map(e => e.name)
+  if (!names.includes('lgtm') || names.includes('hold')) {
+    return false
+  }
 
-        case 'rebase':
-          await octokit.pulls.merge({
-            ...context.repo,
-            pull_number: pr.number,
-            merge_method: 'rebase',
-          })
-          break
+  try {
+    await octokit.pulls.merge({
+      ...context.repo,
+      pull_number: pr.number,
+      merge_method: mergeMethod(method),
+    })
+    return true
+  }
+  catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    core.error(`could not merge pr #${pr.number}: ${message}`)
+    failures.push({ number: pr.number, message })
+    return false
+  }
+}
 
-        default:
-          await octokit.pulls.merge({
-            ...context.repo,
-            pull_number: pr.number,
-            merge_method: 'merge',
-          })
-      }
-    }
-    catch (e) {
-      core.debug(`could not merge pr ${pr.number}: ${e}`)
-    }
+// an unknown merge-method input falls back to 'merge'
+function mergeMethod(input: string): 'merge' | 'squash' | 'rebase' {
+  switch (input) {
+    case 'squash':
+    case 'rebase':
+      return input
+    default:
+      return 'merge'
   }
 }

--- a/src/labels/prefixed.ts
+++ b/src/labels/prefixed.ts
@@ -33,6 +33,15 @@ export const prefixedLabelCommands: PrefixedLabelCommand[] = [
 // a .prowlabels.yaml key usable as a slash command: lower-case letters, digits and dashes
 export const labelCommandName = /^[a-z][a-z0-9-]*$/
 
+// labels with dedicated, authorization-gated commands; never reachable through /label
+const protectedLabels = ['lgtm', 'hold', 'approved']
+const protectedPrefixes = ['do-not-merge/']
+
+export function isProtectedLabel(label: string): boolean {
+  const lower = label.toLowerCase()
+  return protectedLabels.includes(lower) || protectedPrefixes.some(prefix => lower.startsWith(prefix))
+}
+
 /**
  * dynamicPrefixedCommand builds the command for an arbitrary .prowlabels.yaml
  * key so that `/<key> value` labels the issue with '<key>/value'
@@ -91,8 +100,8 @@ export async function addPrefixedLabels(context: Context, cmd: PrefixedLabelComm
 /**
  * removePrefixedLabels removes '<prefix>/<value>' for every value in the
  * /remove-<command> line that is in the .prowlabels.yaml allowlist and
- * currently on the issue. Restricting removal to the allowlist keeps
- * anyone from stripping protected labels such as lgtm, approved or hold.
+ * currently on the issue. Labels owned by other commands (lgtm, hold,
+ * approved, do-not-merge/*) are refused even when the allowlist names them.
  *
  * @param context - the github actions event context
  * @param cmd - the command definition
@@ -175,6 +184,13 @@ function requestedLabels(
   // no arguments after command provided
   if (labels.length === 0) {
     throw new Error(`${command.slice(1)}: command args missing from body`)
+  }
+
+  if (cmd.prefix === '') {
+    const offender = labels.find(isProtectedLabel)
+    if (offender !== undefined) {
+      throw new Error(`${command.slice(1)}: ${offender} is managed by its own command and cannot be changed with ${command}`)
+    }
   }
 
   return labels


### PR DESCRIPTION
# Description

The two medium findings from the docs audit (#140), both behaviour changes decided with the maintainer.

## `fix(labels): never add or remove lgtm, hold or approved via /label`
`/label` and `/remove-label` apply labels verbatim, gated only by the `labels:` allowlist. A repo that listed `lgtm` there let anyone `/remove-label lgtm` — or `/label lgtm`, bypassing OWNERS authorization entirely.

`lgtm`, `hold`, `approved` and anything under `do-not-merge/` are now **always refused** by `/label`/`/remove-label` (case-insensitive), before any API call, with `label: lgtm is managed by its own command and cannot be changed with /label`. The whole command is refused, not partially applied. Prefixed commands are unaffected (`/kind lgtm` → `kind/lgtm`, harmless). Listing the names in `.prowlabels.yaml` remains legal; only using them errors.

## `fix(cron): fail the lgtm job when a merge fails`
Merge failures were `core.debug`'d and swallowed — an operator never learned their auto-merges were failing. Decision: **process every PR, then fail the run.** Each failed merge is a `core.error` annotation (`could not merge pr #3: Pull Request is not mergeable`); after all pages the job throws `N pull request(s) could not be merged: #3 (…), #7 (…)`. One un-mergeable PR never stops the others from being attempted — pinned by a test with two PRs where the first 405s and the second merges.

Also removes a module-level `let jobsDone` counter (latent cross-run pollution) by threading progress through the recursion; return contract to `handleCronJob` unchanged.

## Testing
- **469 → 492 tests**; coverage 93.1 / 92.9 br / 99.4 fn. **No existing assertion changed.**
- Failing-test-first for both (18 and 3 red respectively)
- Two new bundle-harness scenarios against `dist/index.js`: `/remove-label lgtm` refused with exit 1; schedule job with a 405 merge → exit 1, next page still fetched
- Hermetic under a simulated Actions env; `dist/` byte-identical across repeated packs

Docs updated in `commands.md`, `labeling.md`, `automatic-merging.md`.
