### PR TITLE
feat: label-sync job; refuse to apply labels the repository does not have

### DIFF
--- a/.github/prow.yaml
+++ b/.github/prow.yaml
@@ -4,16 +4,24 @@ labels:
     - important
 
   kind:
-    - failing-test
-    - cleanup
+    - name: failing-test
+      color: e11d21
+      description: Categorizes issue or PR as related to a consistently or frequently failing test.
+    - name: cleanup
+      color: c5def5
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
 
   priority:
-    - low
-    - high
+    - name: low
+      color: fef2c0
+    - name: high
+      color: eb6420
 
   # the /label allowlist: applied verbatim, without a prefix
   labels:
-    - documentation
+    - name: documentation
+      color: 0075ca
+      description: Improvements or additions to documentation
     - question
 
   triage:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,20 @@
+name: Sync labels from prow.yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [.github/prow.yaml]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./
+        with:
+          jobs: label-sync
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ This is the full list of available commands. Prow-style aliases (`/unhold`, `/re
 
 Configuration can live in the repo or in your org's `.project`/`.github` repo — see [configuration](./docs/configuration.md).
 
+Label commands only apply labels the repository already has. Create them from the configuration with the `label-sync` job, on demand or whenever `prow.yaml` changes:
+
+```yaml
+name: Sync labels from prow.yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [.github/prow.yaml]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          jobs: label-sync
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```
+
 You can automatically merge PRs based on a cron schedule if it contains the `lgtm` label:
 
 ```yaml
@@ -87,7 +111,7 @@ jobs:
 - [Commands](./docs/commands.md)
 - [Configuration](./docs/configuration.md)
 - [Labeling](./docs/labeling.md)
-- [Cron Jobs](./docs/cron-jobs.md)
+- [Jobs (lgtm merger, label-sync)](./docs/cron-jobs.md)
 - [Automatic PR merging](./docs/automatic-merging.md)
 - [PR jobs](./docs/pr-jobs.md)
 - [Examples](./docs/examples.md)

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -17,6 +17,8 @@ vi.setConfig({ testTimeout: 30_000 })
 
 const repo = '/repos/Codertocat/Hello-World'
 const token = { 'github-token': 'some-token' }
+// the read every label command makes before it applies a label
+const labelsRead = `GET ${repo}/labels?per_page=100`
 
 function comment(body: string, author = issueCommentEvent.issue.user.login) {
   const payload = structuredClone(issueCommentEvent)
@@ -28,6 +30,10 @@ function comment(body: string, author = issueCommentEvent.issue.user.login) {
 function openPr(labels: string[], overrides: Record<string, unknown> = {}) {
   const pr = structuredClone(pullReqListPulls[0])
   return { ...pr, labels: labels.map(name => ({ name })), ...overrides }
+}
+
+function repoLabels(...names: string[]) {
+  return { status: 200, body: names.map(name => ({ name })) }
 }
 
 function yamlFile(text: string) {
@@ -95,6 +101,7 @@ describe('dist/index.js', () => {
 
   it('issue_comment /kind adds a prefixed label from .prowlabels.yaml', async () => {
     gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: labelFileContents })
+    gh.route('GET', `${repo}/labels`, repoLabels('kind/cleanup'))
     gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
 
     const result = await runBundle({
@@ -109,11 +116,30 @@ describe('dist/index.js', () => {
     const posts = gh.requestsMatching('POST', /\/issues\/1\/labels$/)
     expect(posts).toHaveLength(1)
     expect(posts[0].body).toEqual({ labels: ['kind/cleanup'] })
-    expectRequests(configReads({ repo: '.prowlabels.yaml' }), [`POST ${repo}/issues/1/labels`])
+    expectRequests([...configReads({ repo: '.prowlabels.yaml' }), labelsRead], [`POST ${repo}/issues/1/labels`])
+  })
+
+  it('issue_comment /kind refuses a label the repository does not have without posting', async () => {
+    gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: labelFileContents })
+    gh.route('GET', `${repo}/labels`, repoLabels('kind/failing-test'))
+    gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'issue_comment',
+      payload: comment('/kind cleanup'),
+      inputs: { ...token, 'prow-commands': '/kind' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(1)
+    expect(result.errors.some(e => e.includes(`the label(s) kind/cleanup cannot be applied because the repository doesn't have them`))).toBe(true)
+    expect(gh.requestsMatching('POST', /./)).toEqual([])
+    expectRequests([...configReads({ repo: '.prowlabels.yaml' }), labelsRead], [])
   })
 
   it('issue_comment /kind reads labels from the organization .project repo when the repo has no configuration', async () => {
     gh.route('GET', '/repos/Codertocat/.project/contents/prow.yaml', { status: 200, body: yamlFile('labels:\n  kind: [cleanup]\n') })
+    gh.route('GET', `${repo}/labels`, repoLabels('kind/cleanup'))
     gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
 
     const result = await runBundle({
@@ -128,7 +154,7 @@ describe('dist/index.js', () => {
     const posts = gh.requestsMatching('POST', /\/issues\/1\/labels$/)
     expect(posts).toHaveLength(1)
     expect(posts[0].body).toEqual({ labels: ['kind/cleanup'] })
-    expectRequests(configReads({ org: '.project' }), [`POST ${repo}/issues/1/labels`])
+    expectRequests([...configReads({ org: '.project' }), labelsRead], [`POST ${repo}/issues/1/labels`])
   })
 
   it('issue_comment ignores a /kind inside a fenced code block without calling the api', async () => {
@@ -167,6 +193,7 @@ describe('dist/index.js', () => {
 
   it('issue_comment /label adds an allowlisted label verbatim', async () => {
     gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: labelFileContents })
+    gh.route('GET', `${repo}/labels`, repoLabels('good-first-issue'))
     gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
 
     const result = await runBundle({
@@ -181,7 +208,7 @@ describe('dist/index.js', () => {
     const posts = gh.requestsMatching('POST', /\/issues\/1\/labels$/)
     expect(posts).toHaveLength(1)
     expect(posts[0].body).toEqual({ labels: ['good-first-issue'] })
-    expectRequests(configReads({ repo: '.prowlabels.yaml' }), [`POST ${repo}/issues/1/labels`])
+    expectRequests([...configReads({ repo: '.prowlabels.yaml' }), labelsRead], [`POST ${repo}/issues/1/labels`])
   })
 
   it('issue_comment /remove-label refuses lgtm even when .prowlabels.yaml lists it', async () => {
@@ -206,6 +233,7 @@ describe('dist/index.js', () => {
     gh.route('GET', `${repo}/contents/.prowlabels.yaml`, { status: 200, body: labelFileContents })
     gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'level/sandbox' }] } })
     gh.route('DELETE', `${repo}/issues/1/labels/level%2Fsandbox`, { status: 200, body: [] })
+    gh.route('GET', `${repo}/labels`, repoLabels('level/sandbox', 'level/incubation'))
     gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
 
     const result = await runBundle({
@@ -223,11 +251,13 @@ describe('dist/index.js', () => {
     expectRequests(configReads({ repo: '.prowlabels.yaml' }), [
       `GET ${repo}/issues/1`,
       `DELETE ${repo}/issues/1/labels/level%2Fsandbox`,
+      labelsRead,
       `POST ${repo}/issues/1/labels`,
     ])
   })
 
   it('issue_comment /help adds help wanted without reading .prowlabels.yaml', async () => {
+    gh.route('GET', `${repo}/labels`, repoLabels('help wanted'))
     gh.route('POST', `${repo}/issues/1/labels`, { status: 200, body: [] })
 
     const result = await runBundle({
@@ -243,6 +273,7 @@ describe('dist/index.js', () => {
     expect(posts).toHaveLength(1)
     expect(posts[0].body).toEqual({ labels: ['help wanted'] })
     expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      labelsRead,
       `POST ${repo}/issues/1/labels`,
     ])
   })

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -91,11 +91,11 @@ describe('dist/index.js', () => {
   })
 
   it('logs an error for an unsupported event without failing or calling the api', async () => {
-    const result = await runBundle({ eventName: 'push', payload: {}, inputs: token, apiUrl: gh.url })
+    const result = await runBundle({ eventName: 'issues', payload: {}, inputs: token, apiUrl: gh.url })
 
     expect(result.status).toBe(0)
-    expect(result.stdout).toContain('push not yet supported')
-    expect(result.errors).toEqual(['push not yet supported'])
+    expect(result.stdout).toContain('issues not yet supported')
+    expect(result.errors).toEqual(['issues not yet supported'])
     expect(gh.requests).toEqual([])
   })
 
@@ -605,6 +605,61 @@ describe('dist/index.js', () => {
         `PUT ${repo}/pulls/2/merge`,
         `GET ${repo}/pulls?state=open&page=2`,
       ])
+    })
+  })
+
+  describe('workflow_dispatch label-sync job', () => {
+    const orgConfig = yamlFile('labels:\n  kind:\n    - name: bug\n      color: d73a4a\n      description: Something is not working\n    - cleanup\n')
+    const builtins = [
+      'approved',
+      'good first issue',
+      'help wanted',
+      'hold',
+      'lgtm',
+      'lifecycle/frozen',
+      'lifecycle/rotten',
+      'lifecycle/stale',
+      'stage/alpha',
+      'stage/beta',
+      'stage/stable',
+      'status/approved-for-milestone',
+      'status/in-progress',
+      'status/in-review',
+    ]
+
+    it('creates the missing labels, recolors the drifted one and deletes nothing', async () => {
+      gh.route('GET', '/repos/Codertocat/.project/contents/prow.yaml', { status: 200, body: orgConfig })
+      gh.route('GET', `${repo}/labels`, { status: 200, body: [{ name: 'kind/bug', color: '000000', description: 'Something is not working' }, { name: 'unrelated', color: 'ffffff' }] })
+      gh.route('POST', `${repo}/labels`, { status: 201, body: {} })
+      gh.route('PATCH', new RegExp(`^${repo}/labels/`), { status: 200, body: {} })
+
+      const result = await runBundle({
+        eventName: 'workflow_dispatch',
+        payload: {},
+        inputs: { ...token, jobs: 'label-sync' },
+        apiUrl: gh.url,
+      })
+
+      expect(result.status, result.stdout).toBe(0)
+      expect(result.errors).toEqual([])
+      const posts = gh.requestsMatching('POST', /\/labels$/)
+      expect(posts.map(p => (p.body as { name: string }).name)).toEqual([...builtins, 'kind/cleanup'].sort((a, b) => a.localeCompare(b)))
+      expect(posts.find(p => (p.body as { name: string }).name === 'lgtm')!.body).toEqual({
+        name: 'lgtm',
+        color: '15dd18',
+        description: '"Looks good to me", indicates that a PR is ready to be merged.',
+      })
+      expect(posts.find(p => (p.body as { name: string }).name === 'kind/cleanup')!.body).toEqual({ name: 'kind/cleanup' })
+      const patches = gh.requestsMatching('PATCH', /./)
+      expect(patches).toHaveLength(1)
+      expect(patches[0].path).toBe(`${repo}/labels/kind%2Fbug`)
+      expect(patches[0].body).toEqual({ color: 'd73a4a' })
+      expect(gh.requestsMatching('DELETE', /./)).toEqual([])
+      const desired = [...builtins, 'kind/bug', 'kind/cleanup'].sort((a, b) => a.localeCompare(b))
+      expectRequests(
+        [...configReads({ org: '.project' }), labelsRead],
+        desired.map(name => (name === 'kind/bug' ? `PATCH ${repo}/labels/kind%2Fbug` : `POST ${repo}/labels`)),
+      )
     })
   })
 })

--- a/__tests__/cronJobTest/labelSync.test.ts
+++ b/__tests__/cronJobTest/labelSync.test.ts
@@ -1,0 +1,290 @@
+import { Buffer } from 'node:buffer'
+import * as core from '@actions/core'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleCronJobs } from '../../src/cronJobs/handleCronJob'
+import { labelSync } from '../../src/cronJobs/labelSync'
+import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
+import listPullReqs from '../fixtures/pullReq/pullReqListPulls.json'
+import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const repo = `${utils.api}/repos/Codertocat/Hello-World`
+
+interface RepoLabel {
+  name: string
+  color: string
+  description?: string | null
+}
+
+interface Write {
+  method: string
+  name?: string
+  body: unknown
+}
+
+const prowYaml = `
+labels:
+  kind:
+    - name: bug
+      color: d73a4a
+      description: Something is not working
+    - cleanup
+  labels:
+    - documentation
+`
+
+// everything desiredLabels yields for prowYaml, as the repository would hold it
+const complete: RepoLabel[] = [
+  { name: 'approved', color: '0ffa16', description: 'Indicates a PR has been approved by an approver from all required OWNERS files.' },
+  { name: 'documentation', color: 'aaaaaa', description: 'kept as is' },
+  { name: 'good first issue', color: '7057ff', description: 'Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.' },
+  { name: 'help wanted', color: '006b75', description: 'Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.' },
+  { name: 'hold', color: 'e11d21', description: 'Indicates that a PR should not merge because someone has issued a /hold command.' },
+  { name: 'kind/bug', color: 'd73a4a', description: 'Something is not working' },
+  { name: 'kind/cleanup', color: 'bbbbbb', description: null },
+  { name: 'lgtm', color: '15dd18', description: '"Looks good to me", indicates that a PR is ready to be merged.' },
+  { name: 'lifecycle/frozen', color: 'd3e2f0', description: 'Indicates that an issue or PR should not be auto-closed due to staleness.' },
+  { name: 'lifecycle/rotten', color: '604460', description: 'Denotes an issue or PR that has aged beyond stale and will be auto-closed.' },
+  { name: 'lifecycle/stale', color: '795548', description: 'Denotes an issue or PR has remained open with no activity and has become stale.' },
+  { name: 'stage/alpha', color: 'cccccc' },
+  { name: 'stage/beta', color: 'cccccc' },
+  { name: 'stage/stable', color: 'cccccc' },
+  { name: 'status/approved-for-milestone', color: 'cccccc' },
+  { name: 'status/in-progress', color: 'cccccc' },
+  { name: 'status/in-review', color: 'cccccc' },
+]
+
+function withChanges(...changes: RepoLabel[]): RepoLabel[] {
+  return complete.map(label => changes.find(change => change.name === label.name) ?? label)
+}
+
+function dispatchContext() {
+  return new utils.MockContext({ repository: { owner: { login: 'Codertocat' }, name: 'Hello-World' } })
+}
+
+function serveConfig(text = prowYaml) {
+  const file = structuredClone(labelFileContents)
+  file.content = Buffer.from(text).toString('base64')
+  server.use(
+    http.get(`${repo}/contents/.github%2Fprow.yaml`, utils.mockResponse(200, file)),
+    ...utils.noOrgOrRepoConfigExcept('.github/prow.yaml'),
+  )
+}
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json', ...headers } })
+}
+
+function recordWrites(existing: RepoLabel[], createStatus: (name: string) => number = () => 201): Write[] {
+  const writes: Write[] = []
+  server.use(
+    utils.repoHasLabels(existing),
+    http.post(`${repo}/labels`, async ({ request }) => {
+      const body = await request.json() as { name: string }
+      writes.push({ method: 'POST', body })
+      const status = createStatus(body.name)
+      return json(status === 201 ? body : { message: 'Validation Failed' }, status)
+    }),
+    http.patch(`${repo}/labels/:name`, async ({ request, params }) => {
+      writes.push({ method: 'PATCH', name: decodeURIComponent(params.name as string), body: await request.json() })
+      return json({})
+    }),
+    http.delete(`${repo}/labels/:name`, ({ params }) => {
+      writes.push({ method: 'DELETE', name: decodeURIComponent(params.name as string), body: undefined })
+      return new Response(null, { status: 204 })
+    }),
+  )
+  return writes
+}
+
+describe('label-sync job', () => {
+  beforeEach(() => {
+    utils.setupJobsEnv('label-sync')
+  })
+
+  it('creates every missing label with only the fields that are known', async () => {
+    serveConfig()
+    const writes = recordWrites([])
+    const info = vi.spyOn(core, 'info').mockImplementation(() => {})
+
+    const result = await labelSync(dispatchContext())
+
+    expect(writes.every(w => w.method === 'POST')).toBe(true)
+    expect(writes.map(w => (w.body as { name: string }).name)).toEqual(complete.map(l => l.name))
+    expect(writes.find(w => (w.body as { name: string }).name === 'kind/bug')!.body).toEqual({
+      name: 'kind/bug',
+      color: 'd73a4a',
+      description: 'Something is not working',
+    })
+    expect(writes.find(w => (w.body as { name: string }).name === 'kind/cleanup')!.body).toEqual({ name: 'kind/cleanup' })
+    expect(writes.find(w => (w.body as { name: string }).name === 'lgtm')!.body).toMatchObject({ name: 'lgtm', color: '15dd18' })
+    expect(result).toEqual({ created: complete.map(l => l.name), updated: [], unchanged: 0, failures: [] })
+    expect(info).toHaveBeenCalledWith(expect.stringContaining(`created ${complete.length}`))
+  })
+
+  it('updates a label whose color differs and sends only that field', async () => {
+    serveConfig()
+    const writes = recordWrites(withChanges({ name: 'lgtm', color: '000000', description: complete.find(l => l.name === 'lgtm')!.description }))
+
+    const result = await labelSync(dispatchContext())
+
+    expect(writes).toEqual([{ method: 'PATCH', name: 'lgtm', body: { color: '15dd18' } }])
+    expect(result.updated).toEqual(['lgtm'])
+    expect(result.created).toEqual([])
+    expect(result.unchanged).toBe(complete.length - 1)
+  })
+
+  it('updates a label whose description differs', async () => {
+    serveConfig()
+    const writes = recordWrites(withChanges({ name: 'kind/bug', color: 'd73a4a', description: null }))
+
+    await labelSync(dispatchContext())
+
+    expect(writes).toEqual([{ method: 'PATCH', name: 'kind/bug', body: { description: 'Something is not working' } }])
+  })
+
+  it('writes nothing when only the case of the name or color differs, or when the repo has extra metadata', async () => {
+    serveConfig()
+    const observePatch = new utils.ObserveRequest()
+    server.use(http.patch(`${repo}/labels/:name`, utils.mockResponse(200, {}, observePatch)))
+    const writes = recordWrites(withChanges(
+      { name: 'Kind/Bug', color: 'D73A4A', description: 'Something is not working' },
+      { name: 'LGTM', color: '15DD18', description: complete.find(l => l.name === 'lgtm')!.description },
+      { name: 'kind/cleanup', color: 'bbbbbb', description: 'a description the config does not know' },
+    ))
+
+    const result = await labelSync(dispatchContext())
+
+    expect(writes).toEqual([])
+    await expect(observePatch.notCalled()).resolves.toBe('not called')
+    expect(result).toEqual({ created: [], updated: [], unchanged: complete.length, failures: [] })
+  })
+
+  it('never deletes a label the configuration does not mention', async () => {
+    serveConfig()
+    const observeDelete = new utils.ObserveRequest()
+    server.use(http.delete(`${repo}/labels/:name`, utils.mockResponse(204, null, observeDelete)))
+    const writes = recordWrites([...complete, { name: 'obsolete', color: 'ffffff' }, { name: 'kind/legacy', color: 'ffffff' }])
+
+    await labelSync(dispatchContext())
+
+    expect(writes.filter(w => w.method === 'DELETE')).toEqual([])
+    expect(writes).toEqual([])
+    await expect(observeDelete.notCalled()).resolves.toBe('not called')
+  })
+
+  it('reads every page of the repository labels', async () => {
+    serveConfig()
+    const writes = recordWrites([])
+    const half = Math.ceil(complete.length / 2)
+    const pages = new Set<string | null>()
+    server.use(
+      http.get(`${repo}/labels`, ({ request }) => {
+        const url = new URL(request.url)
+        const page = url.searchParams.get('page')
+        pages.add(page)
+        if (page === null || page === '1') {
+          return json(complete.slice(0, half), 200, { Link: `<${repo}/labels?per_page=100&page=2>; rel="next"` })
+        }
+        return json(complete.slice(half))
+      }),
+    )
+
+    const result = await labelSync(dispatchContext())
+
+    expect([...pages]).toEqual([null, '2'])
+    expect(writes).toEqual([])
+    expect(result.unchanged).toBe(complete.length)
+  })
+
+  it('keeps creating after one create fails and then fails the run naming the label', async () => {
+    serveConfig()
+    const writes = recordWrites([], name => (name === 'kind/bug' ? 422 : 201))
+    const logError = vi.spyOn(core, 'error').mockImplementation(() => {})
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await expect(handleCronJobs(dispatchContext())).resolves.toBeUndefined()
+
+    expect(writes.map(w => (w.body as { name: string }).name)).toEqual(complete.map(l => l.name))
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('kind/bug'))
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('kind/bug'))
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('1 label(s) could not be synced'))
+  })
+
+  it('dry-run logs what would change and writes nothing', async () => {
+    process.env['INPUT_DRY-RUN'] = 'true'
+    serveConfig()
+    const writes = recordWrites(withChanges({ name: 'lgtm', color: '000000' }).filter(l => l.name !== 'kind/bug'))
+    const info = vi.spyOn(core, 'info').mockImplementation(() => {})
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleCronJobs(dispatchContext())
+
+    expect(writes).toEqual([])
+    expect(setFailed).not.toHaveBeenCalled()
+    const lines = info.mock.calls.map(([line]) => String(line))
+    expect(lines.some(line => line.includes('would create') && line.includes('kind/bug'))).toBe(true)
+    expect(lines.some(line => line.includes('would update') && line.includes('lgtm'))).toBe(true)
+  })
+
+  it('fails the run when the configuration cannot be loaded', async () => {
+    server.use(
+      http.get(`${repo}/contents/.github%2Fprow.yaml`, utils.mockResponse(500, { message: 'boom' })),
+      ...utils.noOrgOrRepoConfigExcept('.github/prow.yaml'),
+    )
+    const writes = recordWrites([])
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleCronJobs(dispatchContext())
+
+    expect(writes).toEqual([])
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('could not load prow config'))
+  })
+
+  it('runs next to an unknown job, which still fails the run', async () => {
+    utils.setupJobsEnv('label-sync bogus')
+    serveConfig()
+    const writes = recordWrites(complete)
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleCronJobs(dispatchContext())
+
+    expect(writes).toEqual([])
+    expect(setFailed).toHaveBeenCalledWith(expect.stringContaining('could not execute bogus'))
+  })
+
+  it('jobs: lgtm label-sync runs both jobs', async () => {
+    utils.setupJobsEnv('lgtm label-sync')
+    serveConfig()
+    const writes = recordWrites(complete.filter(l => l.name !== 'documentation'))
+    const mergeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(`${repo}/pulls`, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page')
+        const payload = structuredClone(listPullReqs)
+        payload[0].labels[0].name = 'lgtm'
+        return json(page === '1' ? payload : [])
+      }),
+      http.put(`${repo}/pulls/2/merge`, utils.mockResponse(200, null, mergeReq)),
+    )
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleCronJobs(dispatchContext())
+
+    await expect(mergeReq.called()).resolves.toBe('called')
+    expect(writes).toEqual([{ method: 'POST', body: { name: 'documentation' } }])
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/label/area.test.ts
+++ b/__tests__/label/area.test.ts
@@ -42,6 +42,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
     )
 
     server.use(
@@ -69,6 +70,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
     )
 
     server.use(
@@ -96,6 +98,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
     )
 
     server.use(
@@ -123,6 +126,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -154,6 +158,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(500),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
     )
 
     const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
@@ -194,6 +199,7 @@ describe('area', () => {
           return new Response(null, { status: 200 })
         },
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
     )
 
     let resolved = false
@@ -225,6 +231,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('area/important')),
@@ -314,6 +321,7 @@ describe('area', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['area/bug', 'area/important']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('area/important')),

--- a/__tests__/label/dynamic.test.ts
+++ b/__tests__/label/dynamic.test.ts
@@ -43,6 +43,7 @@ function serveIssueAndRecordMutations(currentLabels: string[]): string[] {
     }),
     http.get(`${repo}/issues/1`, utils.mockResponse(200, issueWithLabels(...currentLabels))),
     http.get(`${repo}/contents/.prowlabels.yaml`, utils.mockResponse(200, labelFileContents)),
+    utils.repoHasLabels(['level/incubation', 'level/graduation', 'triage/needs-information']),
 
     ...utils.noOrgOrRepoConfigExcept('.prowlabels.yaml'),
   )

--- a/__tests__/label/help.test.ts
+++ b/__tests__/label/help.test.ts
@@ -43,6 +43,7 @@ function serveIssueAndRecordMutations(currentLabels: string[]) {
     }),
     http.get(`${repo}/issues/1`, utils.mockResponse(200, issueWithLabels(...currentLabels))),
     http.get(`${repo}/contents/:path`, utils.mockResponse(404, null, yamlFetch)),
+    utils.repoHasLabels(['help wanted', 'good first issue']),
   )
   return { mutations, yamlFetch }
 }

--- a/__tests__/label/hold.test.ts
+++ b/__tests__/label/hold.test.ts
@@ -33,6 +33,7 @@ describe('hold', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['hold']),
     )
 
     await handleIssueComment(commentContext)
@@ -52,6 +53,7 @@ describe('hold', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['hold']),
     )
 
     await handleIssueComment(commentContext)
@@ -137,6 +139,7 @@ describe('hold', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReqAdd),
       ),
+      utils.repoHasLabels(['hold']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -176,6 +179,7 @@ describe('hold', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReqAdd),
       ),
+      utils.repoHasLabels(['hold']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),

--- a/__tests__/label/kind.test.ts
+++ b/__tests__/label/kind.test.ts
@@ -42,6 +42,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
     )
 
     server.use(
@@ -69,6 +70,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
     )
 
     server.use(
@@ -96,6 +98,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -122,6 +125,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
     )
 
     server.use(
@@ -149,6 +153,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -179,6 +184,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('kind/cleanup')),
@@ -295,6 +301,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('kind/cleanup')),
@@ -337,6 +344,7 @@ describe('kind', () => {
           return new Response(null, { status: 200 })
         },
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('kind/cleanup')),
@@ -364,6 +372,7 @@ describe('kind', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -430,6 +439,7 @@ describe('kind', () => {
           return new Response(null, { status: 200 })
         },
       ),
+      utils.repoHasLabels(['kind/cleanup', 'kind/failing-test']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('kind/cleanup', 'kind/failing-test')),

--- a/__tests__/label/label.test.ts
+++ b/__tests__/label/label.test.ts
@@ -68,6 +68,7 @@ describe('protected labels', () => {
           `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
           utils.mockResponse(200, null, observePost),
         ),
+        utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
         http.get(
           `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
           utils.mockResponse(200, withProtected),
@@ -127,6 +128,7 @@ describe('protected labels', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, withProtected),
@@ -157,6 +159,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -181,6 +184,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -205,6 +209,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -233,6 +238,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, withoutLabels),
@@ -263,6 +269,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('help-wanted')),
@@ -350,6 +357,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, withSlash),
@@ -384,6 +392,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('tide/merge-method-squash')),
@@ -417,6 +426,7 @@ describe('label', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['good-first-issue', 'help-wanted', 'documentation', 'tide/merge-method-squash']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issueWithLabels('help-wanted')),

--- a/__tests__/label/lgtm.test.ts
+++ b/__tests__/label/lgtm.test.ts
@@ -40,6 +40,7 @@ describe('lgtm', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['lgtm']),
     )
 
     server.use(
@@ -133,6 +134,7 @@ describe('lgtm', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeAdd),
       ),
+      utils.repoHasLabels(['lgtm']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -252,6 +254,7 @@ describe('lgtm', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeAdd),
       ),
+      utils.repoHasLabels(['lgtm']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -287,6 +290,7 @@ describe('lgtm', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['lgtm']),
     )
 
     server.use(
@@ -399,6 +403,7 @@ approvers:
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['lgtm']),
     )
 
     const owners = Buffer.from(
@@ -477,6 +482,7 @@ reviewers:
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['lgtm']),
       http.get(
         `${utils.api}/orgs/Codertocat/members/Codertocat`,
         utils.mockResponse(204),
@@ -516,6 +522,7 @@ reviewers:
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeAdd),
       ),
+      utils.repoHasLabels(['lgtm']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -559,6 +566,7 @@ reviewers:
           `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
           utils.mockResponse(200, null, observeAdd),
         ),
+        utils.repoHasLabels(['lgtm']),
         http.post(
           `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
           utils.mockResponse(200, null, observeComment),
@@ -669,6 +677,7 @@ reviewers:
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['lgtm']),
       ...prHandlers(
         { 'OWNERS': 'approvers:\n- alice\n', 'sdk/OWNERS': 'reviewers:\n- ryan\n' },
         ['sdk/x.go', 'docs/y.md'],
@@ -694,6 +703,7 @@ reviewers:
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeAdd),
       ),
+      utils.repoHasLabels(['lgtm']),
       http.post(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/comments`,
         utils.mockResponse(200, null, observeComment),

--- a/__tests__/label/lifecycle.test.ts
+++ b/__tests__/label/lifecycle.test.ts
@@ -50,6 +50,7 @@ function serveIssueAndRecordMutations(currentLabels: string[], yaml = labelFileC
     }),
     http.get(`${repo}/issues/1`, utils.mockResponse(200, issueWithLabels(...currentLabels))),
     http.get(`${repo}/contents/.prowlabels.yaml`, utils.mockResponse(200, yaml)),
+    utils.repoHasLabels(['lifecycle/frozen', 'lifecycle/stale', 'stage/beta', 'status/in-review']),
 
     ...utils.noOrgOrRepoConfigExcept('.prowlabels.yaml'),
   )

--- a/__tests__/label/priority.test.ts
+++ b/__tests__/label/priority.test.ts
@@ -34,6 +34,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issuePayload),
@@ -62,6 +63,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issuePayload),
@@ -90,6 +92,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issuePayload),
@@ -134,6 +137,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReqPost),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -179,6 +183,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReqPost),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -246,6 +251,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/contents/.prowlabels.yaml`,
         utils.mockResponse(200, labelFileContents),
@@ -279,6 +285,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -374,6 +381,7 @@ describe('priority', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observePost),
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),
@@ -419,6 +427,7 @@ describe('priority', () => {
           return new Response(null, { status: 200 })
         },
       ),
+      utils.repoHasLabels(['priority/low', 'priority/high']),
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, payload),

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -84,14 +84,25 @@ describe('run', () => {
     expect(mockedHandlePullReq).not.toHaveBeenCalled()
   })
 
+  it.each(['workflow_dispatch', 'push'])('dispatches %s to handleCronJobs', async (eventName) => {
+    github.context.eventName = eventName
+    mockedHandleCronJobs.mockResolvedValue()
+
+    await run()
+
+    expect(mockedHandleCronJobs).toHaveBeenCalledTimes(1)
+    expect(mockedHandle).not.toHaveBeenCalled()
+    expect(mockedHandlePullReq).not.toHaveBeenCalled()
+  })
+
   it('logs an error for an unsupported event without failing', async () => {
-    github.context.eventName = 'push'
+    github.context.eventName = 'issues'
     const logError = vi.spyOn(core, 'error').mockImplementation(() => {})
     const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
 
     await expect(run()).resolves.toBeUndefined()
 
-    expect(logError).toHaveBeenCalledWith('push not yet supported')
+    expect(logError).toHaveBeenCalledWith('issues not yet supported')
     expect(setFailed).not.toHaveBeenCalled()
     expect(mockedHandle).not.toHaveBeenCalled()
     expect(mockedHandlePullReq).not.toHaveBeenCalled()

--- a/__tests__/testUtils.ts
+++ b/__tests__/testUtils.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github'
 import { http } from 'msw'
 
 import { resetProwConfigCache } from '../src/utils/config'
+import { resetLabelCache } from '../src/utils/labeling'
 
 type WebhookPayload = Context['payload']
 
@@ -45,6 +46,22 @@ export function noOrgOrRepoConfigExcept(...except: string[]) {
     .map(source => http.get(contentsUrl(source), mockResponse(404, { message: 'Not Found' })))
 }
 
+/**
+ * repoHasLabels serves `GET /repos/Codertocat/Hello-World/labels` with the
+ * given labels on a single page (any `per_page`/`page` query is ignored), so
+ * that label commands may apply them.
+ *
+ * @param labels - names, or `{ name, color?, description? }` entries
+ * @param observeReq - optionally records the request
+ */
+export function repoHasLabels(
+  labels: (string | { name: string, color?: string, description?: string | null })[],
+  observeReq?: ObserveRequest,
+) {
+  const body = labels.map(label => (typeof label === 'string' ? { name: label } : label))
+  return http.get(`${api}/repos/Codertocat/Hello-World/labels`, mockResponse(200, body, observeReq))
+}
+
 // @actions/github exports only the context instance; extend its class via the prototype
 const ContextClass = github.context.constructor as new () => Context
 
@@ -59,9 +76,10 @@ export class MockContext extends ContextClass {
 // Drop action inputs and the runner-provided GITHUB_* variables so that tests
 // are hermetic when they run inside GitHub Actions (github.context reads
 // GITHUB_REPOSITORY, GITHUB_EVENT_PATH, GITHUB_API_URL, ... from the env).
-// The configuration cache lives for one action run, so it is reset here too.
+// The configuration and repository label caches live for one action run, so they are reset here too.
 function clearActionEnv() {
   resetProwConfigCache()
+  resetLabelCache()
   for (const key of Object.keys(process.env)) {
     if (key.startsWith('INPUT_') || key.startsWith('GITHUB_')) {
       delete process.env[key]

--- a/__tests__/utils/labelCatalog.test.ts
+++ b/__tests__/utils/labelCatalog.test.ts
@@ -1,0 +1,154 @@
+import type { ProwConfig } from '../../src/utils/config'
+import { describe, expect, it } from 'vitest'
+
+import { mergeProwConfig, parseProwConfig } from '../../src/utils/config'
+import { builtinLabelDefaults, desiredLabels } from '../../src/utils/labelCatalog'
+
+function configFrom(yaml: string): ProwConfig {
+  return { ...mergeProwConfig({}, parseProwConfig('test', yaml)), sources: ['test'] }
+}
+
+const registryDefaults = [
+  'lifecycle/frozen',
+  'lifecycle/rotten',
+  'lifecycle/stale',
+  'stage/alpha',
+  'stage/beta',
+  'stage/stable',
+  'status/approved-for-milestone',
+  'status/in-progress',
+  'status/in-review',
+]
+
+const actionManaged = ['approved', 'good first issue', 'help wanted', 'hold', 'lgtm']
+
+function names(config: ProwConfig): string[] {
+  return desiredLabels(config).map(label => label.name)
+}
+
+describe('desiredLabels', () => {
+  it('yields the built-ins and the action-managed labels for an empty configuration', () => {
+    expect(names(configFrom(''))).toEqual([...actionManaged, ...registryDefaults].sort((a, b) => a.localeCompare(b)))
+  })
+
+  it('prefixes section values with the key and carries color and description', () => {
+    const labels = desiredLabels(configFrom(`
+labels:
+  kind:
+    - name: bug
+      color: D73A4A
+      description: Something is not working
+    - cleanup
+  area: [api]
+`))
+
+    expect(labels.filter(l => l.name.startsWith('kind/') || l.name.startsWith('area/'))).toEqual([
+      { name: 'area/api' },
+      { name: 'kind/bug', color: 'd73a4a', description: 'Something is not working' },
+      { name: 'kind/cleanup' },
+    ])
+  })
+
+  it('applies the /label allowlist verbatim', () => {
+    const result = names(configFrom('labels:\n  labels: [documentation, question]\n'))
+
+    expect(result).toContain('documentation')
+    expect(result).toContain('question')
+    expect(result.some(name => name.startsWith('labels/'))).toBe(false)
+  })
+
+  it('treats a legacy flat document the same way', () => {
+    const result = names(configFrom('kind: [bug]\nlabels: [documentation]\n'))
+
+    expect(result).toContain('kind/bug')
+    expect(result).toContain('documentation')
+  })
+
+  it('a yaml section replaces the registry defaults of its key', () => {
+    const result = names(configFrom('labels:\n  lifecycle: [frozen]\n'))
+
+    expect(result).toContain('lifecycle/frozen')
+    expect(result).not.toContain('lifecycle/stale')
+    expect(result).not.toContain('lifecycle/rotten')
+    expect(result).toContain('stage/alpha')
+  })
+
+  it('includes dynamic sections outside the registry', () => {
+    expect(names(configFrom('labels:\n  level:\n    values: [sandbox, incubation]\n    exclusive: true\n'))).toEqual(
+      expect.arrayContaining(['level/sandbox', 'level/incubation']),
+    )
+  })
+
+  it('includes the configured hold label next to hold', () => {
+    const labels = desiredLabels(configFrom('hold:\n  label: do-not-merge/hold\n'))
+
+    expect(labels.map(l => l.name)).toEqual(expect.arrayContaining(['hold', 'do-not-merge/hold']))
+    expect(labels.find(l => l.name === 'do-not-merge/hold')).toEqual({
+      name: 'do-not-merge/hold',
+      ...builtinLabelDefaults['do-not-merge/hold'],
+    })
+  })
+
+  it('includes every require_matching_label missing label with the needs- color', () => {
+    const labels = desiredLabels(configFrom(`
+require_matching_label:
+  - regexp: ^kind/
+    missing_label: needs-kind
+  - regexp: ^area/
+    missing_label: triage/unlabeled
+`))
+
+    expect(labels.find(l => l.name === 'needs-kind')).toEqual({ name: 'needs-kind', color: 'ededed' })
+    expect(labels.find(l => l.name === 'triage/unlabeled')).toEqual({ name: 'triage/unlabeled' })
+  })
+
+  it('de-duplicates case-insensitively, first definition wins', () => {
+    const labels = desiredLabels(configFrom(`
+labels:
+  labels:
+    - name: LGTM
+      color: '111111'
+    - name: Documentation
+      description: first
+    - name: documentation
+      description: second
+`))
+
+    expect(labels.filter(l => l.name.toLowerCase() === 'lgtm')).toEqual([{ name: 'LGTM', color: '111111', description: builtinLabelDefaults.lgtm.description }])
+    expect(labels.filter(l => l.name.toLowerCase() === 'documentation')).toEqual([{ name: 'Documentation', description: 'first' }])
+  })
+
+  it('is sorted by name', () => {
+    const result = names(configFrom('labels:\n  kind: [zeta, alpha]\n  area: [mid]\n'))
+
+    expect(result).toEqual([...result].sort((a, b) => a.localeCompare(b)))
+  })
+
+  it('lets the configuration override a built-in default and leaves unknown labels without a color', () => {
+    const labels = desiredLabels(configFrom(`
+labels:
+  lifecycle:
+    - name: stale
+      color: 123abc
+    - frozen
+  kind: [bug]
+`))
+
+    expect(labels.find(l => l.name === 'lifecycle/stale')).toEqual({
+      name: 'lifecycle/stale',
+      color: '123abc',
+      description: builtinLabelDefaults['lifecycle/stale'].description,
+    })
+    expect(labels.find(l => l.name === 'lifecycle/frozen')).toEqual({ name: 'lifecycle/frozen', ...builtinLabelDefaults['lifecycle/frozen'] })
+    expect(labels.find(l => l.name === 'kind/bug')).toEqual({ name: 'kind/bug' })
+    expect(labels.find(l => l.name === 'stage/alpha')).toEqual({ name: 'stage/alpha' })
+  })
+
+  it('gives every action-managed label its built-in color', () => {
+    const labels = desiredLabels(configFrom(''))
+
+    for (const name of actionManaged) {
+      expect(labels.find(l => l.name === name)).toEqual({ name, ...builtinLabelDefaults[name] })
+    }
+  })
+})

--- a/__tests__/utils/labeling.test.ts
+++ b/__tests__/utils/labeling.test.ts
@@ -7,7 +7,7 @@ import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleIssueComment } from '../../src/issueComment/handleIssueComment'
-import { addPrefix, getArgumentLabels, getLabelConfig } from '../../src/utils/labeling'
+import { addPrefix, assertLabelsExist, getArgumentLabels, getLabelConfig, labelIssue } from '../../src/utils/labeling'
 import { newOctokit } from '../../src/utils/octokit'
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
 
@@ -39,6 +39,7 @@ describe('utils labeling', () => {
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels`,
         utils.mockResponse(200, null, observeReq),
       ),
+      utils.repoHasLabels(['area/important']),
     )
 
     server.use(
@@ -89,6 +90,77 @@ describe('utils labeling', () => {
 
   it('addPrefix leaves args unchanged for an empty prefix', () => {
     expect(addPrefix('', ['good-first-issue'])).toEqual(['good-first-issue'])
+  })
+})
+
+describe('labelIssue refuses labels the repository does not have', () => {
+  const context = new utils.MockContext(issueCommentEvent)
+  const repo = `${utils.api}/repos/Codertocat/Hello-World`
+  let octokit: Octokit
+
+  beforeEach(() => {
+    utils.setupActionsEnv()
+    octokit = newOctokit('some-token')
+  })
+
+  it('throws naming exactly the missing labels and does not post', async () => {
+    const observePost = new utils.ObserveRequest()
+    server.use(
+      http.post(`${repo}/issues/1/labels`, utils.mockResponse(200, null, observePost)),
+      utils.repoHasLabels(['kind/bug']),
+    )
+
+    await expect(labelIssue(octokit, context, 1, ['kind/bug', 'kind/cleanup', 'area/api'])).rejects.toThrow(
+      `the label(s) kind/cleanup, area/api cannot be applied because the repository doesn't have them. Run the label-sync job or create them.`,
+    )
+    await expect(observePost.notCalled()).resolves.toBe('not called')
+  })
+
+  it('posts when every label exists, matching names case-insensitively', async () => {
+    const observePost = new utils.ObserveRequest()
+    server.use(
+      http.post(`${repo}/issues/1/labels`, utils.mockResponse(200, null, observePost)),
+      utils.repoHasLabels(['Kind/Bug', 'help wanted']),
+    )
+
+    await labelIssue(octokit, context, 1, ['kind/bug'])
+
+    await observePost.called()
+    expect(await observePost.body()).toEqual({ labels: ['kind/bug'] })
+  })
+
+  it('reads the repository labels once per run', async () => {
+    const observeLabels = new utils.ObserveRequest()
+    let reads = 0
+    server.use(
+      http.post(`${repo}/issues/1/labels`, utils.mockResponse(200, null)),
+      http.get(`${repo}/labels`, async ({ request }) => {
+        reads++
+        observeLabels.ref = request
+        return new Response(JSON.stringify([{ name: 'lgtm' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }),
+    )
+
+    await labelIssue(octokit, context, 1, ['lgtm'])
+    await labelIssue(octokit, context, 1, ['lgtm'])
+
+    expect(reads).toBe(1)
+    expect(new URL(observeLabels.ref!.url).searchParams.get('per_page')).toBe('100')
+  })
+
+  it('assertLabelsExist follows pagination', async () => {
+    server.use(
+      http.get(`${repo}/labels`, ({ request }) => {
+        const page = new URL(request.url).searchParams.get('page')
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        if (page === null) {
+          headers.Link = `<${repo}/labels?per_page=100&page=2>; rel="next"`
+        }
+        return new Response(JSON.stringify([{ name: page === null ? 'first' : 'second' }]), { status: 200, headers })
+      }),
+    )
+
+    await expect(assertLabelsExist(octokit, context, ['second', 'first'])).resolves.toBeUndefined()
   })
 })
 

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,12 @@ inputs:
     description: Comment keywords/commands to look for. Space delimited. Expect commands on own line. Prow-style aliases (e.g. /unhold, /remove-lgtm) are enabled with their base command, and listing an alias enables the whole command family (e.g. /remove-kind also enables /kind).
     required: false
   jobs:
-    description: The jobs to automatically run on event. Space or newline delimited.
+    description: "The jobs to run for schedule, workflow_dispatch, push and pull_request events. Space or newline delimited: 'lgtm' (merge lgtm PRs on a schedule, remove lgtm on pull_request), 'label-sync' (create and update the repository labels from the prow configuration; never deletes)."
     required: false
+  dry-run:
+    description: "When 'true', the label-sync job logs the labels it would create or update and writes nothing. Defaults to 'false'."
+    required: false
+    default: 'false'
   merge-method:
     description: "Strategy for Prow-github-actions to take when merging a pull request using the lgtm cron-job. Can be 'squash', 'rebase', or 'merge'. Defaults to 'merge'"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -37189,231 +37189,6 @@ function getOctokit(token, options, ...additionalPlugins) {
     return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
 //# sourceMappingURL=github.js.map
-;// CONCATENATED MODULE: external "node:process"
-const external_node_process_namespaceObject = require("node:process");
-var external_node_process_default = /*#__PURE__*/__nccwpck_require__.n(external_node_process_namespaceObject);
-;// CONCATENATED MODULE: ./node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log/dist-src/version.js
-const plugin_request_log_dist_src_version_VERSION = "6.0.0";
-
-
-;// CONCATENATED MODULE: ./node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log/dist-src/index.js
-
-function requestLog(octokit) {
-  octokit.hook.wrap("request", (request, options) => {
-    octokit.log.debug("request", options);
-    const start = Date.now();
-    const requestOptions = octokit.request.endpoint.parse(options);
-    const path = requestOptions.url.replace(options.baseUrl, "");
-    return request(options).then((response) => {
-      const requestId = response.headers["x-github-request-id"];
-      octokit.log.info(
-        `${requestOptions.method} ${path} - ${response.status} with id ${requestId} in ${Date.now() - start}ms`
-      );
-      return response;
-    }).catch((error) => {
-      const requestId = error.response?.headers["x-github-request-id"] || "UNKNOWN";
-      octokit.log.error(
-        `${requestOptions.method} ${path} - ${error.status} with id ${requestId} in ${Date.now() - start}ms`
-      );
-      throw error;
-    });
-  });
-}
-requestLog.VERSION = plugin_request_log_dist_src_version_VERSION;
-
-
-;// CONCATENATED MODULE: ./node_modules/@octokit/rest/dist-src/version.js
-const rest_dist_src_version_VERSION = "22.0.1";
-
-
-;// CONCATENATED MODULE: ./node_modules/@octokit/rest/dist-src/index.js
-
-
-
-
-
-const dist_src_Octokit = Octokit.plugin(requestLog, legacyRestEndpointMethods, paginateRest).defaults(
-  {
-    userAgent: `octokit-rest.js/${rest_dist_src_version_VERSION}`
-  }
-);
-
-
-;// CONCATENATED MODULE: ./lib/utils/octokit.js
-
-
-// GITHUB_API_URL is set by the runner and differs on GitHub Enterprise Server
-function newOctokit(token) {
-    return new dist_src_Octokit({
-        auth: token,
-        baseUrl: (external_node_process_default()).env.GITHUB_API_URL || 'https://api.github.com',
-    });
-}
-
-;// CONCATENATED MODULE: ./lib/cronJobs/lgtm.js
-
-
-
-/**
- * Inspired by https://github.com/actions/stale
- * this will recurse through the pages of PRs for a repo
- * and attempt to merge them if they have the "lgtm" label.
- * Every PR is attempted; once all pages are processed the run fails
- * if any merge was refused, listing the affected PRs.
- *
- * @param currentPage - the page to return from the github api
- * @param context - The github actions event context
- * @param progress - merges done and failures collected on earlier pages
- */
-async function cronLgtm(currentPage, context, progress = { jobsDone: 0, failures: [] }) {
-    info(`starting lgtm merger page: ${currentPage}`);
-    const token = getInput('github-token', { required: true });
-    const octokit = newOctokit(token);
-    // Get next batch
-    let prs;
-    try {
-        prs = await getOpenPrs(octokit, context, currentPage);
-    }
-    catch (e) {
-        throw new Error(`could not get PRs: ${e}`);
-    }
-    if (prs.length <= 0) {
-        // All done!
-        if (progress.failures.length > 0) {
-            const list = progress.failures.map(f => `#${f.number} (${f.message})`).join(', ');
-            throw new Error(`${progress.failures.length} pull request(s) could not be merged: ${list}`);
-        }
-        return progress.jobsDone;
-    }
-    const results = await Promise.all(prs.map(async (pr) => {
-        info(`processing pr: ${pr.number}`);
-        if (pr.state === 'closed') {
-            return;
-        }
-        if (pr.locked) {
-            return;
-        }
-        try {
-            if (await tryMergePr(pr, octokit, context, progress.failures)) {
-                progress.jobsDone++;
-            }
-        }
-        catch (error) {
-            return error;
-        }
-    }));
-    for (const result of results) {
-        if (result instanceof Error) {
-            throw new TypeError(`error processing pr: ${result}`);
-        }
-    }
-    // Recurse, continue to next page
-    return await cronLgtm(currentPage + 1, context, progress);
-}
-/**
- * grabs pulls from github in baches of 100
- *
- * @param octokit - a hydrated github client
- * @param context - the github actions workflow context
- * @param page - the page number to get from the api
- */
-async function getOpenPrs(octokit, context = github_context, page) {
-    core_debug(`getting prs page ${page}...`);
-    const prResults = await octokit.pulls.list({
-        ...context.repo,
-        state: 'open',
-        page,
-    });
-    core_debug(`got: ${prResults.data}`);
-    return prResults.data;
-}
-/**
- * Attempts to merge a PR if it has the lgtm label and not the hold label.
- * A refused merge is logged as an error annotation and recorded in
- * failures instead of aborting the run.
- *
- * @param pr - the PR to try and merge
- * @param octokit - a hydrated github api client
- * @param context - the github actions event context
- * @param failures - collects PRs whose merge the api refused
- * @returns whether the PR was merged
- */
-async function tryMergePr(pr, octokit, context = github_context, failures) {
-    const method = getInput('merge-method', { required: false });
-    const names = pr.labels.map(e => e.name);
-    if (!names.includes('lgtm') || names.includes('hold')) {
-        return false;
-    }
-    try {
-        await octokit.pulls.merge({
-            ...context.repo,
-            pull_number: pr.number,
-            merge_method: mergeMethod(method),
-        });
-        return true;
-    }
-    catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        error(`could not merge pr #${pr.number}: ${message}`);
-        failures.push({ number: pr.number, message });
-        return false;
-    }
-}
-// an unknown merge-method input falls back to 'merge'
-function mergeMethod(input) {
-    switch (input) {
-        case 'squash':
-        case 'rebase':
-            return input;
-        default:
-            return 'merge';
-    }
-}
-
-;// CONCATENATED MODULE: ./lib/cronJobs/handleCronJob.js
-
-
-
-/**
- * This Method handles any cron job events.
- * A user should define which of the jobs they want to run in their workflow yaml
- *
- * @param context - the github context of the current action event
- */
-async function handleCronJobs(context = github_context) {
-    const runConfig = getInput('jobs', { required: false })
-        .split(/\s+/)
-        .filter(command => command !== '')
-        .map(command => command.toLowerCase());
-    if (runConfig.length === 0) {
-        runConfig.push('');
-    }
-    await Promise.all(runConfig.map(async (command) => {
-        switch (command) {
-            case 'lgtm':
-                core_debug('running cronLgtm job');
-                return await cronLgtm(1, context).catch(async (e) => {
-                    return e;
-                });
-            case '':
-                return new Error(`please provide a list of space delimited commands / jobs to run. None found`);
-            default:
-                return new Error(`could not execute ${command}. May not be supported - please refer to docs`);
-        }
-    }))
-        .then((results) => {
-        // Check to see if any of the promises failed
-        for (const result of results) {
-            if (result instanceof Error) {
-                throw new TypeError(`error handling issue comment: ${result}`);
-            }
-        }
-    })
-        .catch((e) => {
-        setFailed(`${e}`);
-    });
-}
-
 // EXTERNAL MODULE: external "node:buffer"
 var external_node_buffer_ = __nccwpck_require__(4573);
 ;// CONCATENATED MODULE: ./node_modules/js-yaml/dist/js-yaml.mjs
@@ -41352,6 +41127,158 @@ function stripUndefined(value) {
     return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined));
 }
 
+;// CONCATENATED MODULE: ./lib/utils/command.js
+/**
+ * hasCommand reports whether the command starts a line of the body
+ * (leading whitespace allowed) so that mentions mid-sentence and
+ * longer commands sharing a prefix (/remove-lgtm vs /lgtm) do not match
+ *
+ * @param command - the command to look for. Ex: '/assign'
+ * @param body - the full body of the comment
+ */
+function hasCommand(command, body) {
+    return findCommandArgs(command, body).length > 0;
+}
+/**
+ * getLineArgs will return the trimmed text following the command on its line.
+ * When the command appears on several lines the last one wins, which suits
+ * single-valued commands such as /milestone and /retitle
+ * Ex return: 'some-user some-other-user'
+ *
+ * @param command - the given command to get arguments for. Ex: '/assign'
+ * @param body - the full body of the comment
+ */
+function getLineArgs(command, body) {
+    return findCommandArgs(command, body).at(-1) ?? '';
+}
+/**
+ * getCommandArgs will return an array of the arguments associated with a command,
+ * collected in order from every line that carries it and de-duplicated
+ * Ex return: [`some-user', 'some-other-user']
+ *
+ * @param command - the given command to get arguments for. Ex: '/assign'
+ * @param body - the full body of the comment
+ */
+function getCommandArgs(command, body) {
+    const rests = findCommandArgs(command, body);
+    if (rests.length === 0) {
+        throw new Error(`command ${command} missing from body`);
+    }
+    const args = rests.flatMap(rest => rest.split(/\s+/).filter(Boolean));
+    return [...new Set(stripAtSign(args))];
+}
+/**
+ * hasKeyword reports whether a command keyword such as 'cancel' or 'clear'
+ * is among the arguments, ignoring case like Prow's (?i) plugin regexes
+ *
+ * @param args - the arguments returned by getCommandArgs
+ * @param keyword - the lowercase keyword to look for
+ */
+function hasKeyword(args, keyword) {
+    return args.some(arg => arg.toLowerCase() === keyword);
+}
+function findCommandArgs(command, body) {
+    const pattern = commandPattern(command);
+    const found = [];
+    for (const line of commandLines(body)) {
+        const match = pattern.exec(line);
+        if (match) {
+            found.push((match[1] ?? '').trim());
+        }
+    }
+    return found;
+}
+const indentedCode = /^(?: {4}| {0,3}\t)/;
+// CommonMark fence: up to 3 spaces then 3+ backticks or tildes; the closer uses the same character, is at least as long and is alone on its line
+const fenceLine = /^ {0,3}(`{3,}(?!`)|~{3,}(?!~))(.*)$/;
+/**
+ * commandLines returns the lines of the body that can carry a command:
+ * everything except Markdown code (fenced ``` / ~~~ blocks and indented code)
+ *
+ * @param body - the full body of the comment
+ */
+function commandLines(body) {
+    const visible = [];
+    let fence;
+    let inIndentedCode = false;
+    let afterBlockBoundary = true;
+    for (const line of splitLines(body)) {
+        if (fence) {
+            if (closesFence(line, fence)) {
+                fence = undefined;
+                afterBlockBoundary = true;
+            }
+            continue;
+        }
+        if (line.trim() === '') {
+            visible.push(line);
+            inIndentedCode = false;
+            afterBlockBoundary = true;
+            continue;
+        }
+        // simplification: indented code only after a blank line, a fence or the start of the body; paragraph and list continuations stay visible
+        if (indentedCode.test(line) && (afterBlockBoundary || inIndentedCode)) {
+            inIndentedCode = true;
+            continue;
+        }
+        inIndentedCode = false;
+        afterBlockBoundary = false;
+        const opener = fenceOpener(line);
+        if (opener) {
+            fence = opener;
+            continue;
+        }
+        visible.push(line);
+    }
+    return visible;
+}
+function fenceOpener(line) {
+    const match = fenceLine.exec(line);
+    if (!match)
+        return undefined;
+    const char = match[1][0];
+    if (char === '`' && match[2].includes('`'))
+        return undefined;
+    return { char, length: match[1].length };
+}
+function closesFence(line, fence) {
+    const match = fenceLine.exec(line);
+    if (!match)
+        return false;
+    return match[1][0] === fence.char
+        && match[1].length >= fence.length
+        && match[2].trim() === '';
+}
+function commandPattern(command) {
+    // escape regex metacharacters so a command is matched literally
+    const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
+    return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`, 'i');
+}
+// splitLines splits a comment body into lines, tolerating CRLF and CR endings
+function splitLines(body) {
+    return body.replace(/\r\n?/g, '\n').split('\n');
+}
+/**
+ * stripAtSign will remove a leading '@' sign from the arguments array
+ * This is necessary as some commands may have arguments with users tagged with
+ * a leading at sign. Ex: /assign @some-user
+ *
+ * @param args - the array to remove at signs from
+ */
+function stripAtSign(args) {
+    const toReturn = [];
+    for (const e of args) {
+        if (e.startsWith('@')) {
+            toReturn.push(e.replace('@', ''));
+        }
+        else {
+            toReturn.push(e);
+        }
+    }
+    return toReturn;
+}
+
 ;// CONCATENATED MODULE: ./lib/utils/labeling.js
 
 
@@ -41560,156 +41487,65 @@ function labeling_isNotFound(error) {
         && error.status === 404);
 }
 
-;// CONCATENATED MODULE: ./lib/utils/command.js
-/**
- * hasCommand reports whether the command starts a line of the body
- * (leading whitespace allowed) so that mentions mid-sentence and
- * longer commands sharing a prefix (/remove-lgtm vs /lgtm) do not match
- *
- * @param command - the command to look for. Ex: '/assign'
- * @param body - the full body of the comment
- */
-function hasCommand(command, body) {
-    return findCommandArgs(command, body).length > 0;
+;// CONCATENATED MODULE: external "node:process"
+const external_node_process_namespaceObject = require("node:process");
+var external_node_process_default = /*#__PURE__*/__nccwpck_require__.n(external_node_process_namespaceObject);
+;// CONCATENATED MODULE: ./node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log/dist-src/version.js
+const plugin_request_log_dist_src_version_VERSION = "6.0.0";
+
+
+;// CONCATENATED MODULE: ./node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log/dist-src/index.js
+
+function requestLog(octokit) {
+  octokit.hook.wrap("request", (request, options) => {
+    octokit.log.debug("request", options);
+    const start = Date.now();
+    const requestOptions = octokit.request.endpoint.parse(options);
+    const path = requestOptions.url.replace(options.baseUrl, "");
+    return request(options).then((response) => {
+      const requestId = response.headers["x-github-request-id"];
+      octokit.log.info(
+        `${requestOptions.method} ${path} - ${response.status} with id ${requestId} in ${Date.now() - start}ms`
+      );
+      return response;
+    }).catch((error) => {
+      const requestId = error.response?.headers["x-github-request-id"] || "UNKNOWN";
+      octokit.log.error(
+        `${requestOptions.method} ${path} - ${error.status} with id ${requestId} in ${Date.now() - start}ms`
+      );
+      throw error;
+    });
+  });
 }
-/**
- * getLineArgs will return the trimmed text following the command on its line.
- * When the command appears on several lines the last one wins, which suits
- * single-valued commands such as /milestone and /retitle
- * Ex return: 'some-user some-other-user'
- *
- * @param command - the given command to get arguments for. Ex: '/assign'
- * @param body - the full body of the comment
- */
-function getLineArgs(command, body) {
-    return findCommandArgs(command, body).at(-1) ?? '';
-}
-/**
- * getCommandArgs will return an array of the arguments associated with a command,
- * collected in order from every line that carries it and de-duplicated
- * Ex return: [`some-user', 'some-other-user']
- *
- * @param command - the given command to get arguments for. Ex: '/assign'
- * @param body - the full body of the comment
- */
-function getCommandArgs(command, body) {
-    const rests = findCommandArgs(command, body);
-    if (rests.length === 0) {
-        throw new Error(`command ${command} missing from body`);
-    }
-    const args = rests.flatMap(rest => rest.split(/\s+/).filter(Boolean));
-    return [...new Set(stripAtSign(args))];
-}
-/**
- * hasKeyword reports whether a command keyword such as 'cancel' or 'clear'
- * is among the arguments, ignoring case like Prow's (?i) plugin regexes
- *
- * @param args - the arguments returned by getCommandArgs
- * @param keyword - the lowercase keyword to look for
- */
-function hasKeyword(args, keyword) {
-    return args.some(arg => arg.toLowerCase() === keyword);
-}
-function findCommandArgs(command, body) {
-    const pattern = commandPattern(command);
-    const found = [];
-    for (const line of commandLines(body)) {
-        const match = pattern.exec(line);
-        if (match) {
-            found.push((match[1] ?? '').trim());
-        }
-    }
-    return found;
-}
-const indentedCode = /^(?: {4}| {0,3}\t)/;
-// CommonMark fence: up to 3 spaces then 3+ backticks or tildes; the closer uses the same character, is at least as long and is alone on its line
-const fenceLine = /^ {0,3}(`{3,}(?!`)|~{3,}(?!~))(.*)$/;
-/**
- * commandLines returns the lines of the body that can carry a command:
- * everything except Markdown code (fenced ``` / ~~~ blocks and indented code)
- *
- * @param body - the full body of the comment
- */
-function commandLines(body) {
-    const visible = [];
-    let fence;
-    let inIndentedCode = false;
-    let afterBlockBoundary = true;
-    for (const line of splitLines(body)) {
-        if (fence) {
-            if (closesFence(line, fence)) {
-                fence = undefined;
-                afterBlockBoundary = true;
-            }
-            continue;
-        }
-        if (line.trim() === '') {
-            visible.push(line);
-            inIndentedCode = false;
-            afterBlockBoundary = true;
-            continue;
-        }
-        // simplification: indented code only after a blank line, a fence or the start of the body; paragraph and list continuations stay visible
-        if (indentedCode.test(line) && (afterBlockBoundary || inIndentedCode)) {
-            inIndentedCode = true;
-            continue;
-        }
-        inIndentedCode = false;
-        afterBlockBoundary = false;
-        const opener = fenceOpener(line);
-        if (opener) {
-            fence = opener;
-            continue;
-        }
-        visible.push(line);
-    }
-    return visible;
-}
-function fenceOpener(line) {
-    const match = fenceLine.exec(line);
-    if (!match)
-        return undefined;
-    const char = match[1][0];
-    if (char === '`' && match[2].includes('`'))
-        return undefined;
-    return { char, length: match[1].length };
-}
-function closesFence(line, fence) {
-    const match = fenceLine.exec(line);
-    if (!match)
-        return false;
-    return match[1][0] === fence.char
-        && match[1].length >= fence.length
-        && match[2].trim() === '';
-}
-function commandPattern(command) {
-    // escape regex metacharacters so a command is matched literally
-    const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // group 1 captures the argument remainder so matcher and tokenizer agree on whitespace
-    return new RegExp(`^\\s*${escaped}(?:\\s+(.*))?\\s*$`, 'i');
-}
-// splitLines splits a comment body into lines, tolerating CRLF and CR endings
-function splitLines(body) {
-    return body.replace(/\r\n?/g, '\n').split('\n');
-}
-/**
- * stripAtSign will remove a leading '@' sign from the arguments array
- * This is necessary as some commands may have arguments with users tagged with
- * a leading at sign. Ex: /assign @some-user
- *
- * @param args - the array to remove at signs from
- */
-function stripAtSign(args) {
-    const toReturn = [];
-    for (const e of args) {
-        if (e.startsWith('@')) {
-            toReturn.push(e.replace('@', ''));
-        }
-        else {
-            toReturn.push(e);
-        }
-    }
-    return toReturn;
+requestLog.VERSION = plugin_request_log_dist_src_version_VERSION;
+
+
+;// CONCATENATED MODULE: ./node_modules/@octokit/rest/dist-src/version.js
+const rest_dist_src_version_VERSION = "22.0.1";
+
+
+;// CONCATENATED MODULE: ./node_modules/@octokit/rest/dist-src/index.js
+
+
+
+
+
+const dist_src_Octokit = Octokit.plugin(requestLog, legacyRestEndpointMethods, paginateRest).defaults(
+  {
+    userAgent: `octokit-rest.js/${rest_dist_src_version_VERSION}`
+  }
+);
+
+
+;// CONCATENATED MODULE: ./lib/utils/octokit.js
+
+
+// GITHUB_API_URL is set by the runner and differs on GitHub Enterprise Server
+function newOctokit(token) {
+    return new dist_src_Octokit({
+        auth: token,
+        baseUrl: (external_node_process_default()).env.GITHUB_API_URL || 'https://api.github.com',
+    });
 }
 
 ;// CONCATENATED MODULE: ./lib/labels/prefixed.js
@@ -41813,20 +41649,38 @@ function requireIssueNumber(context) {
     }
     return issueNumber;
 }
-// the yaml section wins over the built-in defaults; a yaml `exclusive` wins over the registry
+/**
+ * sectionFor resolves the label section a command reads: the yaml section
+ * wins over the built-in defaults, and a yaml `exclusive` wins over the
+ * registry. Undefined when neither exists.
+ *
+ * @param labels - the label sections of the prow configuration
+ * @param cmd - the command definition
+ */
+function sectionFor(labels, cmd) {
+    const section = labels[cmd.allowlistKey];
+    if (section) {
+        return { ...section, exclusive: section.exclusive ?? cmd.exclusive };
+    }
+    if (cmd.defaultValues) {
+        return {
+            values: cmd.defaultValues,
+            exclusive: cmd.exclusive,
+            definitions: cmd.defaultValues.map(name => ({ name })),
+        };
+    }
+    return undefined;
+}
 async function allowlistFor(octokit, context, cmd) {
     const key = cmd.allowlistKey;
     try {
-        const section = (await getLabelConfig(octokit, context))[key];
-        if (section) {
-            core_debug(`${key}: found labels ${section.values}`);
-            return { values: section.values, exclusive: section.exclusive ?? cmd.exclusive ?? false };
+        const labels = await getLabelConfig(octokit, context);
+        const section = sectionFor(labels, cmd);
+        if (section === undefined) {
+            throw new Error(`${key}: yaml malformed, expected '${key}' top level key`);
         }
-        if (cmd.defaultValues) {
-            core_debug(`${key}: using built-in labels ${cmd.defaultValues}`);
-            return { values: cmd.defaultValues, exclusive: cmd.exclusive ?? false };
-        }
-        throw new Error(`${key}: yaml malformed, expected '${key}' top level key`);
+        core_debug(`${key}: ${key in labels ? 'found' : 'using built-in'} labels ${section.values}`);
+        return { values: section.values, exclusive: section.exclusive ?? false };
     }
     catch (e) {
         throw new Error(`could not get labels from yaml: ${e}`);
@@ -41864,6 +41718,356 @@ async function currentIssueLabels(octokit, context, issueNumber, command) {
     catch (e) {
         throw new Error(`could not get labels from issue: ${e}`);
     }
+}
+
+;// CONCATENATED MODULE: ./lib/utils/labelCatalog.js
+
+/**
+ * Colors and descriptions of the labels the action manages itself. They
+ * follow kubernetes/test-infra's label_sync where a label exists there;
+ * `hold` mirrors `do-not-merge/hold`.
+ */
+const builtinLabelDefaults = {
+    'lgtm': { color: '15dd18', description: '"Looks good to me", indicates that a PR is ready to be merged.' },
+    'approved': { color: '0ffa16', description: 'Indicates a PR has been approved by an approver from all required OWNERS files.' },
+    'hold': { color: 'e11d21', description: 'Indicates that a PR should not merge because someone has issued a /hold command.' },
+    'do-not-merge/hold': { color: 'e11d21', description: 'Indicates that a PR should not merge because someone has issued a /hold command.' },
+    'help wanted': { color: '006b75', description: 'Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.' },
+    'good first issue': { color: '7057ff', description: 'Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.' },
+    'lifecycle/frozen': { color: 'd3e2f0', description: 'Indicates that an issue or PR should not be auto-closed due to staleness.' },
+    'lifecycle/stale': { color: '795548', description: 'Denotes an issue or PR has remained open with no activity and has become stale.' },
+    'lifecycle/rotten': { color: '604460', description: 'Denotes an issue or PR that has aged beyond stale and will be auto-closed.' },
+};
+const needsLabelColor = 'ededed';
+/**
+ * desiredLabels lists every label the prow configuration describes, with the
+ * color and description the label-sync job should give it: the label
+ * sections (prefixed `<key>/<value>`, the `/label` allowlist verbatim), the
+ * built-in `/lifecycle`, `/stage` and `/status` values where the yaml has no
+ * section, the labels the action's own commands apply, and every
+ * `require_matching_label` missing label. Names are unique
+ * case-insensitively (first definition wins) and sorted.
+ *
+ * @param config - the merged prow configuration
+ */
+function desiredLabels(config) {
+    const registryKeys = new Set(prefixedLabelCommands.map(cmd => cmd.allowlistKey));
+    const labels = [];
+    for (const cmd of prefixedLabelCommands) {
+        const section = sectionFor(config.labels, cmd);
+        if (section) {
+            labels.push(...section.definitions.map(value => prefixed(cmd.prefix, value)));
+        }
+    }
+    for (const [key, section] of Object.entries(config.labels)) {
+        if (!registryKeys.has(key)) {
+            labels.push(...section.definitions.map(value => prefixed(key, value)));
+        }
+    }
+    const holdLabels = config.hold.label === undefined ? ['hold'] : ['hold', config.hold.label];
+    for (const name of ['lgtm', 'approved', ...holdLabels, 'help wanted', 'good first issue']) {
+        labels.push({ name });
+    }
+    for (const rule of config.require_matching_label) {
+        labels.push({ name: rule.missing_label });
+    }
+    const seen = new Set();
+    const unique = labels.filter((label) => {
+        const key = label.name.toLowerCase();
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+    return unique
+        .map(labelCatalog_withDefaults)
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+function prefixed(prefix, value) {
+    return prefix === '' ? { ...value } : { ...value, name: `${prefix}/${value.name}` };
+}
+// the configuration wins over the built-in defaults; a label with neither gets no color
+function labelCatalog_withDefaults(label) {
+    const defaults = builtinLabelDefaults[label.name.toLowerCase()]
+        ?? (label.name.toLowerCase().startsWith('needs-') ? { color: needsLabelColor } : {});
+    const merged = { name: label.name };
+    const color = label.color ?? defaults.color;
+    const description = label.description ?? defaults.description;
+    if (color !== undefined) {
+        merged.color = color.toLowerCase();
+    }
+    if (description !== undefined) {
+        merged.description = description;
+    }
+    return merged;
+}
+
+;// CONCATENATED MODULE: ./lib/cronJobs/labelSync.js
+
+
+
+
+
+/**
+ * labelSync creates the labels the prow configuration describes and updates
+ * the color or description of those that drifted. It never deletes or
+ * renames a label. With the `dry-run` input set it only logs what would
+ * change. Every label is attempted; the run fails at the end if any write
+ * was refused.
+ *
+ * @param context - the github actions event context
+ */
+async function labelSync(context = github_context) {
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    const dryRun = getInput('dry-run', { required: false }).trim().toLowerCase() === 'true';
+    const config = await loadProwConfig(octokit, context);
+    const desired = desiredLabels(config);
+    core_debug(`label-sync: ${desired.length} labels from ${config.sources.length === 0 ? 'the built-in defaults only' : config.sources.join(', ')}`);
+    let existing;
+    try {
+        existing = await octokit.paginate(octokit.issues.listLabelsForRepo, { ...context.repo, per_page: 100 });
+    }
+    catch (e) {
+        throw new Error(`could not list the repository labels: ${e}`);
+    }
+    const byName = new Map(existing.map(label => [label.name.toLowerCase(), label]));
+    const result = { created: [], updated: [], unchanged: 0, failures: [] };
+    const plan = { create: [], update: [] };
+    for (const label of desired) {
+        const current = byName.get(label.name.toLowerCase());
+        if (current === undefined) {
+            plan.create.push(label.name);
+            if (!dryRun) {
+                await write(result, label.name, result.created, () => createLabel(octokit, context, label));
+            }
+            continue;
+        }
+        const patch = drift(label, current);
+        if (patch === undefined) {
+            result.unchanged++;
+            continue;
+        }
+        plan.update.push(`${current.name} (${Object.keys(patch).join(', ')})`);
+        if (!dryRun) {
+            await write(result, current.name, result.updated, () => updateLabel(octokit, context, current.name, patch));
+        }
+    }
+    if (dryRun) {
+        info(`label-sync (dry-run): would create ${plan.create.length} [${plan.create.join(', ')}], would update ${plan.update.length} [${plan.update.join(', ')}], unchanged ${result.unchanged}`);
+        return result;
+    }
+    info(`label-sync: created ${result.created.length} [${result.created.join(', ')}], updated ${result.updated.length} [${result.updated.join(', ')}], unchanged ${result.unchanged}, failed ${result.failures.length}`);
+    if (result.failures.length > 0) {
+        const list = result.failures.map(f => `${f.name} (${f.message})`).join(', ');
+        throw new Error(`${result.failures.length} label(s) could not be synced: ${list}`);
+    }
+    return result;
+}
+// a refused write is logged and recorded so the remaining labels are still attempted
+async function write(result, name, done, action) {
+    try {
+        await action();
+        done.push(name);
+    }
+    catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        error(`label-sync: could not sync ${name}: ${message}`);
+        result.failures.push({ name, message });
+    }
+}
+function createLabel(octokit, context, label) {
+    return octokit.issues.createLabel({
+        ...context.repo,
+        name: label.name,
+        ...(label.color === undefined ? {} : { color: label.color }),
+        ...(label.description === undefined ? {} : { description: label.description }),
+    });
+}
+function updateLabel(octokit, context, name, patch) {
+    return octokit.issues.updateLabel({ ...context.repo, name, ...patch });
+}
+// the fields of `desired` that the repository's label does not match; undefined when in sync
+function drift(desired, current) {
+    const patch = {};
+    if (desired.color !== undefined && desired.color.toLowerCase() !== current.color.toLowerCase()) {
+        patch.color = desired.color;
+    }
+    if (desired.description !== undefined && desired.description !== (current.description ?? '')) {
+        patch.description = desired.description;
+    }
+    return Object.keys(patch).length === 0 ? undefined : patch;
+}
+
+;// CONCATENATED MODULE: ./lib/cronJobs/lgtm.js
+
+
+
+/**
+ * Inspired by https://github.com/actions/stale
+ * this will recurse through the pages of PRs for a repo
+ * and attempt to merge them if they have the "lgtm" label.
+ * Every PR is attempted; once all pages are processed the run fails
+ * if any merge was refused, listing the affected PRs.
+ *
+ * @param currentPage - the page to return from the github api
+ * @param context - The github actions event context
+ * @param progress - merges done and failures collected on earlier pages
+ */
+async function cronLgtm(currentPage, context, progress = { jobsDone: 0, failures: [] }) {
+    info(`starting lgtm merger page: ${currentPage}`);
+    const token = getInput('github-token', { required: true });
+    const octokit = newOctokit(token);
+    // Get next batch
+    let prs;
+    try {
+        prs = await getOpenPrs(octokit, context, currentPage);
+    }
+    catch (e) {
+        throw new Error(`could not get PRs: ${e}`);
+    }
+    if (prs.length <= 0) {
+        // All done!
+        if (progress.failures.length > 0) {
+            const list = progress.failures.map(f => `#${f.number} (${f.message})`).join(', ');
+            throw new Error(`${progress.failures.length} pull request(s) could not be merged: ${list}`);
+        }
+        return progress.jobsDone;
+    }
+    const results = await Promise.all(prs.map(async (pr) => {
+        info(`processing pr: ${pr.number}`);
+        if (pr.state === 'closed') {
+            return;
+        }
+        if (pr.locked) {
+            return;
+        }
+        try {
+            if (await tryMergePr(pr, octokit, context, progress.failures)) {
+                progress.jobsDone++;
+            }
+        }
+        catch (error) {
+            return error;
+        }
+    }));
+    for (const result of results) {
+        if (result instanceof Error) {
+            throw new TypeError(`error processing pr: ${result}`);
+        }
+    }
+    // Recurse, continue to next page
+    return await cronLgtm(currentPage + 1, context, progress);
+}
+/**
+ * grabs pulls from github in baches of 100
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions workflow context
+ * @param page - the page number to get from the api
+ */
+async function getOpenPrs(octokit, context = github_context, page) {
+    core_debug(`getting prs page ${page}...`);
+    const prResults = await octokit.pulls.list({
+        ...context.repo,
+        state: 'open',
+        page,
+    });
+    core_debug(`got: ${prResults.data}`);
+    return prResults.data;
+}
+/**
+ * Attempts to merge a PR if it has the lgtm label and not the hold label.
+ * A refused merge is logged as an error annotation and recorded in
+ * failures instead of aborting the run.
+ *
+ * @param pr - the PR to try and merge
+ * @param octokit - a hydrated github api client
+ * @param context - the github actions event context
+ * @param failures - collects PRs whose merge the api refused
+ * @returns whether the PR was merged
+ */
+async function tryMergePr(pr, octokit, context = github_context, failures) {
+    const method = getInput('merge-method', { required: false });
+    const names = pr.labels.map(e => e.name);
+    if (!names.includes('lgtm') || names.includes('hold')) {
+        return false;
+    }
+    try {
+        await octokit.pulls.merge({
+            ...context.repo,
+            pull_number: pr.number,
+            merge_method: mergeMethod(method),
+        });
+        return true;
+    }
+    catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        error(`could not merge pr #${pr.number}: ${message}`);
+        failures.push({ number: pr.number, message });
+        return false;
+    }
+}
+// an unknown merge-method input falls back to 'merge'
+function mergeMethod(input) {
+    switch (input) {
+        case 'squash':
+        case 'rebase':
+            return input;
+        default:
+            return 'merge';
+    }
+}
+
+;// CONCATENATED MODULE: ./lib/cronJobs/handleCronJob.js
+
+
+
+
+/**
+ * This Method handles any cron job events.
+ * A user should define which of the jobs they want to run in their workflow yaml
+ *
+ * @param context - the github context of the current action event
+ */
+async function handleCronJobs(context = github_context) {
+    const runConfig = getInput('jobs', { required: false })
+        .split(/\s+/)
+        .filter(command => command !== '')
+        .map(command => command.toLowerCase());
+    if (runConfig.length === 0) {
+        runConfig.push('');
+    }
+    await Promise.all(runConfig.map(async (command) => {
+        switch (command) {
+            case 'lgtm':
+                core_debug('running cronLgtm job');
+                return await cronLgtm(1, context).catch(async (e) => {
+                    return e;
+                });
+            case 'label-sync':
+                core_debug('running label-sync job');
+                return await labelSync(context).catch(async (e) => {
+                    return e;
+                });
+            case '':
+                return new Error(`please provide a list of space delimited commands / jobs to run. None found`);
+            default:
+                return new Error(`could not execute ${command}. May not be supported - please refer to docs`);
+        }
+    }))
+        .then((results) => {
+        // Check to see if any of the promises failed
+        for (const result of results) {
+            if (result instanceof Error) {
+                throw new TypeError(`error handling issue comment: ${result}`);
+            }
+        }
+    })
+        .catch((e) => {
+        setFailed(`${e}`);
+    });
 }
 
 ;// CONCATENATED MODULE: ./lib/labels/fixed.js
@@ -43574,6 +43778,8 @@ async function run() {
                 await handlePullReq();
                 break;
             case 'schedule':
+            case 'workflow_dispatch':
+            case 'push':
                 await handleCronJobs();
                 break;
             default:

--- a/dist/index.js
+++ b/dist/index.js
@@ -41390,7 +41390,9 @@ async function getArgumentLabels(octokit, context, arg) {
     return section.values;
 }
 /**
- * labelIssue will label the issue with the labels provided
+ * labelIssue will label the issue with the labels provided. Like Prow, a
+ * label the repository does not have is refused rather than created by
+ * GitHub with a default color.
  *
  * @param octokit - a hydrated github client
  * @param context - the github actions event context
@@ -41398,6 +41400,7 @@ async function getArgumentLabels(octokit, context, arg) {
  * @param labels - the labels to add to the issue
  */
 async function labelIssue(octokit, context, issueNum, labels) {
+    await assertLabelsExist(octokit, context, labels);
     try {
         await octokit.issues.addLabels({
             ...context.repo,
@@ -41407,6 +41410,50 @@ async function labelIssue(octokit, context, issueNum, labels) {
     }
     catch (e) {
         throw new Error(`could not add labels: ${e}`);
+    }
+}
+const repoLabelCache = new Map();
+/**
+ * repoLabelNames lists the names of every label of the event repository,
+ * memoized per repository for the lifetime of the process.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions event context
+ */
+function repoLabelNames(octokit, context) {
+    const key = `${context.repo.owner}/${context.repo.repo}`;
+    let pending = repoLabelCache.get(key);
+    if (pending === undefined) {
+        pending = octokit
+            .paginate(octokit.issues.listLabelsForRepo, { ...context.repo, per_page: 100 })
+            .then(labels => labels.map(label => label.name));
+        repoLabelCache.set(key, pending);
+    }
+    return pending;
+}
+function resetLabelCache() {
+    repoLabelCache.clear();
+}
+/**
+ * assertLabelsExist throws, naming every offender, when one of the labels is
+ * not defined in the repository. Names compare case-insensitively.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions event context
+ * @param labels - the labels about to be applied
+ */
+async function assertLabelsExist(octokit, context, labels) {
+    let existing;
+    try {
+        existing = await repoLabelNames(octokit, context);
+    }
+    catch (e) {
+        throw new Error(`could not list the repository labels: ${e}`);
+    }
+    const known = new Set(existing.map(name => name.toLowerCase()));
+    const missing = labels.filter(label => !known.has(label.toLowerCase()));
+    if (missing.length > 0) {
+        throw new Error(`the label(s) ${missing.join(', ')} cannot be applied because the repository doesn't have them. Run the label-sync job or create them.`);
     }
 }
 /**

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,7 +63,7 @@ Label Commands | Policy | Description
 `/remove-<key> [value1 value2 ...]` | anyone | removes `<key>/<value>` label(s) listed under `<key>` in the prow configuration ([configuration](./configuration.md))
 `/remove [label1 label2 ...]` | Collaborators | removes a specified label(s) on an issue / PR
 
-The `/remove-<key>` commands are enabled together with their base command and only remove values listed in the prow configuration ([configuration](./configuration.md)), so anyone may use them. `lgtm`, `hold`, `approved` and `do-not-merge/*` are always refused by `/label` and `/remove-label`, even when listed under `labels:`; the run fails with `<label> is managed by its own command`. Use `/lgtm`, `/hold` and `/approve` for those, and `/remove` for arbitrary labels.
+Every label command applies only labels the repository already defines ([labeling](./labeling.md#labels-must-exist-in-the-repository)); a missing label fails the run with `the label(s) <names> cannot be applied because the repository doesn't have them`. The `/remove-<key>` commands are enabled together with their base command and only remove values listed in the prow configuration ([configuration](./configuration.md)), so anyone may use them. `lgtm`, `hold`, `approved` and `do-not-merge/*` are always refused by `/label` and `/remove-label`, even when listed under `labels:`; the run fails with `<label> is managed by its own command`. Use `/lgtm`, `/hold` and `/approve` for those, and `/remove` for arbitrary labels.
 
 ## What happens when you are not authorized
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,8 +111,9 @@ Value form | Meaning
 `bug` | the label `key/bug`
 `{ name: bug, color: d73a4a, description: … }` | the same label with metadata; `color` is six hex digits, no `#`
 
-Only `name` is acted upon today. `color` and `description` are parsed and validated for a
-later release that reconciles labels on GitHub.
+`color` and `description` are applied by the [`label-sync` job](./cron-jobs.md#label-sync);
+label commands themselves only use `name`. Quote a color made only of digits
+(`color: '123456'`) so YAML keeps it a string.
 
 The `/label` allowlist is the section named `labels` inside `labels`:
 
@@ -122,10 +123,66 @@ labels:
     - documentation
 ```
 
+### The label catalogue
+
+The [`label-sync` job](./cron-jobs.md#label-sync) creates and updates the union of:
+
+Source | Labels | Color, description
+--- | --- | ---
+every `labels.<key>` section | `<key>/<value>`; the `/label` allowlist `labels.labels` verbatim | from the value's `color` and `description`
+built-in `/lifecycle`, `/stage`, `/status` values | `lifecycle/frozen`, `lifecycle/stale`, `lifecycle/rotten`, `stage/alpha`, `stage/beta`, `stage/stable`, `status/approved-for-milestone`, `status/in-progress`, `status/in-review` | only when the configuration has no section of that key
+the action's own commands | `lgtm`, `approved`, `hold` (and `hold.label` when set), `help wanted`, `good first issue` | built-in
+`require_matching_label` | every `missing_label` | `ededed` for `needs-*`
+
+Precedence per label: the configuration's `color`/`description`, then the built-in
+default, otherwise none (GitHub picks a color; no description is written). Built-in
+colors follow [kubernetes/test-infra `label_sync`](https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.yaml)
+where the label exists there:
+
+Label | Color
+--- | ---
+`lgtm` | `15dd18`
+`approved` | `0ffa16`
+`hold`, `do-not-merge/hold` | `e11d21`
+`help wanted` | `006b75`
+`good first issue` | `7057ff`
+`lifecycle/frozen` | `d3e2f0`
+`lifecycle/stale` | `795548`
+`lifecycle/rotten` | `604460`
+`needs-*` | `ededed`
+
+Names are unique case-insensitively (the first definition wins) and the job never
+deletes or renames a label. Label commands refuse labels the repository does not have
+([labeling](./labeling.md#labels-must-exist-in-the-repository)), so run the job after
+changing the configuration:
+
+```yaml
+name: Sync labels from prow.yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [.github/prow.yaml]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          jobs: label-sync
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```
+
 ### `require_matching_label`
 
 A list of rules, each modelled on Prow's plugin of the same name. Parsed and validated;
-enforcement lands in a later release.
+enforcement lands in a later release. Each `missing_label` is part of the
+[label catalogue](#the-label-catalogue).
 
 Field | Required | Meaning
 --- | --- | ---
@@ -149,7 +206,8 @@ Field | Meaning
 ### `hold`
 
 Parsed and validated; enforcement lands in a later release. Today `/hold` applies the
-`hold` label.
+`hold` label. A configured `label` is added to the [label catalogue](#the-label-catalogue)
+next to `hold`.
 
 Field | Meaning
 --- | ---

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -1,12 +1,65 @@
-# Cron jobs
+# Jobs
 
-The following jobs are supported through [cron Github workflows](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).
-The `jobs` input is space or newline delimited and case-insensitive (`jobs: lgtm`).
-The job pages through the repository's pull requests, following pages until one comes back empty, and skips locked and closed PRs.
+Jobs run from the `jobs` input on `schedule`, `workflow_dispatch` and `push` events
+(`pull_request` runs the [PR jobs](./pr-jobs.md)). The input is space or newline
+delimited and case-insensitive (`jobs: lgtm label-sync`). Every listed job runs; an
+unknown name fails the run with `could not execute <job>`.
 
-Jobs | Description
+Jobs | Description | Permissions
+--- | --- | ---
+`lgtm` | Pages through the repository's open pull requests, following pages until one comes back empty, and merges every one that carries `lgtm` and not `hold`. Skips locked and closed PRs. See [automatic PR merging](./automatic-merging.md). Removed by the [lgtm PR job on pr update](./pr-jobs.md) | `contents: write`, `pull-requests: write`
+`label-sync` | Creates the labels the prow configuration describes and updates the color or description of those that drifted. Never deletes or renames a label. | `contents: read`, `issues: write`
+
+## `label-sync`
+
+The job reconciles the repository's labels with the catalogue derived from the
+[configuration](./configuration.md#the-label-catalogue): every label section, the
+built-in `/lifecycle`, `/stage` and `/status` values, the labels the action's own
+commands apply (`lgtm`, `approved`, `hold`, `help wanted`, `good first issue`) and every
+`require_matching_label` missing label. Label commands only apply labels that exist
+([labeling](./labeling.md#labels-must-exist-in-the-repository)), so run this job once
+after adopting the action and whenever the configuration changes.
+
+Repository label | Action
 --- | ---
-`lgtm` | Will attempt to automatically merge a PR with the `lgtm` label. Blocked by the `hold` label. See [automatic PR merging](./automatic-merging.md). Removed by the [lgtm PR job on pr update](./pr-jobs.md)
+absent | created with the catalogue's name, color and description
+present, color or description differs | updated in place; only the differing fields are sent
+present, only the name's case differs | left alone; the repository's casing wins
+present with a description the catalogue lacks | left alone; nothing is ever cleared
+not in the catalogue | left alone; nothing is ever deleted
+
+Every label is attempted; a refused write is logged as an error annotation and the run
+fails at the end with `N label(s) could not be synced: <name> (<reason>), ...`. One
+`core.info` line summarises what was created, updated and unchanged.
+
+```yaml
+name: Sync labels from prow.yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [.github/prow.yaml]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          jobs: label-sync
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```
+
+Input | Default | Meaning
+--- | --- | ---
+`dry-run` | `false` | `true` logs `would create [...]`, `would update [...]` and writes nothing
+
+When the configuration lives in the organization's `.project` or `.github` repository, a
+`schedule` trigger (for example daily) picks up changes made there.
 
 Removed: `pr-labeler` — the deprecated cron job that labeled PRs by file globs from
 `.github/labels.yaml` has been removed. Use

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -10,6 +10,21 @@ The examples below use the legacy flat form, where every top level key is a labe
 section. In a `prow.yaml` with other sections the same keys sit under `labels:`; the
 `/label` allowlist is then `labels: { labels: [...] }`.
 
+## Labels must exist in the repository
+
+Like Prow's `label` plugin, a command only applies labels the repository already
+defines; GitHub is never left to create one with a default color. Names are compared
+case-insensitively. When any requested label is missing the run fails without adding
+anything:
+
+```text
+the label(s) kind/cleanup, area/api cannot be applied because the repository doesn't have them. Run the label-sync job or create them.
+```
+
+Run the [`label-sync` job](./cron-jobs.md#label-sync) to create every label the
+configuration describes, or create them by hand. `/remove-` forms are not gated.
+The repository's labels are read once per run.
+
 ## Any key is a command
 
 Every label section can be used as a `/<key>` command once it is

--- a/docs/labeling.md
+++ b/docs/labeling.md
@@ -108,7 +108,8 @@ Command | Built-in values
 `/status` | `approved-for-milestone`, `in-progress`, `in-review`
 
 All three are exclusive, so `/lifecycle stale` removes an existing `lifecycle/rotten`.
-A `lifecycle`, `stage` or `status` key in the yaml replaces the built-in values;
+A `lifecycle`, `stage` or `status` key in the yaml replaces the built-in values, for
+the commands and for the [`label-sync` job](./cron-jobs.md#label-sync) alike;
 the mapping form can also set `exclusive: false`:
 
 ```yaml

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,7 @@ that can be run with specific [Github "events"](https://docs.github.com/en/actio
 - [Labeling issues](./labeling.md)
 - [Automatically Labeling PRs](./examples.md#pr-labeler) (via `actions/labeler` with `pull_request_target`)
 - [Automatic PR merging](./automatic-merging.md)
-  - [Available cron jobs](./cron-jobs.md)
+  - [Available jobs: lgtm merger, label-sync](./cron-jobs.md)
 - [Jobs to run on PR update](./pr-jobs.md)
 - [Examples](./examples.md)
 - [Releasing](./releasing.md)

--- a/src/cronJobs/handleCronJob.ts
+++ b/src/cronJobs/handleCronJob.ts
@@ -4,6 +4,7 @@ import * as core from '@actions/core'
 
 import * as github from '@actions/github'
 
+import { labelSync } from './labelSync'
 import { cronLgtm } from './lgtm'
 
 /**
@@ -29,6 +30,12 @@ export async function handleCronJobs(context: Context = github.context): Promise
         case 'lgtm':
           core.debug('running cronLgtm job')
           return await cronLgtm(1, context).catch(async (e) => {
+            return e
+          })
+
+        case 'label-sync':
+          core.debug('running label-sync job')
+          return await labelSync(context).catch(async (e) => {
             return e
           })
 

--- a/src/cronJobs/labelSync.ts
+++ b/src/cronJobs/labelSync.ts
@@ -1,0 +1,138 @@
+import type { Octokit } from '@octokit/rest'
+import type { LabelValue } from '../utils/config'
+import type { Context } from '../utils/context'
+
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+
+import { loadProwConfig } from '../utils/config'
+import { desiredLabels } from '../utils/labelCatalog'
+import { newOctokit } from '../utils/octokit'
+
+export interface LabelSyncFailure {
+  name: string
+  message: string
+}
+
+export interface LabelSyncResult {
+  created: string[]
+  updated: string[]
+  unchanged: number
+  failures: LabelSyncFailure[]
+}
+
+interface RepoLabel {
+  name: string
+  color: string
+  description?: string | null
+}
+
+type LabelPatch = Partial<Pick<LabelValue, 'color' | 'description'>>
+
+/**
+ * labelSync creates the labels the prow configuration describes and updates
+ * the color or description of those that drifted. It never deletes or
+ * renames a label. With the `dry-run` input set it only logs what would
+ * change. Every label is attempted; the run fails at the end if any write
+ * was refused.
+ *
+ * @param context - the github actions event context
+ */
+export async function labelSync(context: Context = github.context): Promise<LabelSyncResult> {
+  const token = core.getInput('github-token', { required: true })
+  const octokit = newOctokit(token)
+  const dryRun = core.getInput('dry-run', { required: false }).trim().toLowerCase() === 'true'
+
+  const config = await loadProwConfig(octokit, context)
+  const desired = desiredLabels(config)
+  core.debug(`label-sync: ${desired.length} labels from ${config.sources.length === 0 ? 'the built-in defaults only' : config.sources.join(', ')}`)
+
+  let existing: RepoLabel[]
+  try {
+    existing = await octokit.paginate(octokit.issues.listLabelsForRepo, { ...context.repo, per_page: 100 })
+  }
+  catch (e) {
+    throw new Error(`could not list the repository labels: ${e}`)
+  }
+  const byName = new Map(existing.map(label => [label.name.toLowerCase(), label]))
+
+  const result: LabelSyncResult = { created: [], updated: [], unchanged: 0, failures: [] }
+  const plan = { create: [] as string[], update: [] as string[] }
+
+  for (const label of desired) {
+    const current = byName.get(label.name.toLowerCase())
+
+    if (current === undefined) {
+      plan.create.push(label.name)
+      if (!dryRun) {
+        await write(result, label.name, result.created, () => createLabel(octokit, context, label))
+      }
+      continue
+    }
+
+    const patch = drift(label, current)
+    if (patch === undefined) {
+      result.unchanged++
+      continue
+    }
+
+    plan.update.push(`${current.name} (${Object.keys(patch).join(', ')})`)
+    if (!dryRun) {
+      await write(result, current.name, result.updated, () => updateLabel(octokit, context, current.name, patch))
+    }
+  }
+
+  if (dryRun) {
+    core.info(`label-sync (dry-run): would create ${plan.create.length} [${plan.create.join(', ')}], would update ${plan.update.length} [${plan.update.join(', ')}], unchanged ${result.unchanged}`)
+    return result
+  }
+
+  core.info(`label-sync: created ${result.created.length} [${result.created.join(', ')}], updated ${result.updated.length} [${result.updated.join(', ')}], unchanged ${result.unchanged}, failed ${result.failures.length}`)
+
+  if (result.failures.length > 0) {
+    const list = result.failures.map(f => `${f.name} (${f.message})`).join(', ')
+    throw new Error(`${result.failures.length} label(s) could not be synced: ${list}`)
+  }
+
+  return result
+}
+
+// a refused write is logged and recorded so the remaining labels are still attempted
+async function write(result: LabelSyncResult, name: string, done: string[], action: () => Promise<unknown>): Promise<void> {
+  try {
+    await action()
+    done.push(name)
+  }
+  catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    core.error(`label-sync: could not sync ${name}: ${message}`)
+    result.failures.push({ name, message })
+  }
+}
+
+function createLabel(octokit: Octokit, context: Context, label: LabelValue): Promise<unknown> {
+  return octokit.issues.createLabel({
+    ...context.repo,
+    name: label.name,
+    ...(label.color === undefined ? {} : { color: label.color }),
+    ...(label.description === undefined ? {} : { description: label.description }),
+  })
+}
+
+function updateLabel(octokit: Octokit, context: Context, name: string, patch: LabelPatch): Promise<unknown> {
+  return octokit.issues.updateLabel({ ...context.repo, name, ...patch })
+}
+
+// the fields of `desired` that the repository's label does not match; undefined when in sync
+function drift(desired: LabelValue, current: RepoLabel): LabelPatch | undefined {
+  const patch: LabelPatch = {}
+
+  if (desired.color !== undefined && desired.color.toLowerCase() !== current.color.toLowerCase()) {
+    patch.color = desired.color
+  }
+  if (desired.description !== undefined && desired.description !== (current.description ?? '')) {
+    patch.description = desired.description
+  }
+
+  return Object.keys(patch).length === 0 ? undefined : patch
+}

--- a/src/labels/prefixed.ts
+++ b/src/labels/prefixed.ts
@@ -1,6 +1,6 @@
 import type { Octokit } from '@octokit/rest'
 import type { Context } from '../utils/context'
-import type { LabelSection } from '../utils/labeling'
+import type { LabelConfig, LabelSection } from '../utils/labeling'
 import * as core from '@actions/core'
 
 import { getCommandArgs } from '../utils/command'
@@ -140,7 +140,32 @@ function requireIssueNumber(context: Context): number {
   return issueNumber
 }
 
-// the yaml section wins over the built-in defaults; a yaml `exclusive` wins over the registry
+/**
+ * sectionFor resolves the label section a command reads: the yaml section
+ * wins over the built-in defaults, and a yaml `exclusive` wins over the
+ * registry. Undefined when neither exists.
+ *
+ * @param labels - the label sections of the prow configuration
+ * @param cmd - the command definition
+ */
+export function sectionFor(labels: LabelConfig, cmd: PrefixedLabelCommand): LabelSection | undefined {
+  const section = labels[cmd.allowlistKey]
+
+  if (section) {
+    return { ...section, exclusive: section.exclusive ?? cmd.exclusive }
+  }
+
+  if (cmd.defaultValues) {
+    return {
+      values: cmd.defaultValues,
+      exclusive: cmd.exclusive,
+      definitions: cmd.defaultValues.map(name => ({ name })),
+    }
+  }
+
+  return undefined
+}
+
 async function allowlistFor(
   octokit: Octokit,
   context: Context,
@@ -149,19 +174,15 @@ async function allowlistFor(
   const key = cmd.allowlistKey
 
   try {
-    const section = (await getLabelConfig(octokit, context))[key]
+    const labels = await getLabelConfig(octokit, context)
+    const section = sectionFor(labels, cmd)
 
-    if (section) {
-      core.debug(`${key}: found labels ${section.values}`)
-      return { values: section.values, exclusive: section.exclusive ?? cmd.exclusive ?? false }
+    if (section === undefined) {
+      throw new Error(`${key}: yaml malformed, expected '${key}' top level key`)
     }
 
-    if (cmd.defaultValues) {
-      core.debug(`${key}: using built-in labels ${cmd.defaultValues}`)
-      return { values: cmd.defaultValues, exclusive: cmd.exclusive ?? false }
-    }
-
-    throw new Error(`${key}: yaml malformed, expected '${key}' top level key`)
+    core.debug(`${key}: ${key in labels ? 'found' : 'using built-in'} labels ${section.values}`)
+    return { values: section.values, exclusive: section.exclusive ?? false }
   }
   catch (e) {
     throw new Error(`could not get labels from yaml: ${e}`)

--- a/src/run.ts
+++ b/src/run.ts
@@ -17,6 +17,8 @@ export async function run(): Promise<void> {
         break
 
       case 'schedule':
+      case 'workflow_dispatch':
+      case 'push':
         await handleCronJobs()
         break
 

--- a/src/utils/labelCatalog.ts
+++ b/src/utils/labelCatalog.ts
@@ -1,0 +1,94 @@
+import type { LabelValue, ProwConfig } from './config'
+
+import { prefixedLabelCommands, sectionFor } from '../labels/prefixed'
+
+/**
+ * Colors and descriptions of the labels the action manages itself. They
+ * follow kubernetes/test-infra's label_sync where a label exists there;
+ * `hold` mirrors `do-not-merge/hold`.
+ */
+export const builtinLabelDefaults: Record<string, Omit<LabelValue, 'name'>> = {
+  'lgtm': { color: '15dd18', description: '"Looks good to me", indicates that a PR is ready to be merged.' },
+  'approved': { color: '0ffa16', description: 'Indicates a PR has been approved by an approver from all required OWNERS files.' },
+  'hold': { color: 'e11d21', description: 'Indicates that a PR should not merge because someone has issued a /hold command.' },
+  'do-not-merge/hold': { color: 'e11d21', description: 'Indicates that a PR should not merge because someone has issued a /hold command.' },
+  'help wanted': { color: '006b75', description: 'Denotes an issue that needs help from a contributor. Must meet "help wanted" guidelines.' },
+  'good first issue': { color: '7057ff', description: 'Denotes an issue ready for a new contributor, according to the "help wanted" guidelines.' },
+  'lifecycle/frozen': { color: 'd3e2f0', description: 'Indicates that an issue or PR should not be auto-closed due to staleness.' },
+  'lifecycle/stale': { color: '795548', description: 'Denotes an issue or PR has remained open with no activity and has become stale.' },
+  'lifecycle/rotten': { color: '604460', description: 'Denotes an issue or PR that has aged beyond stale and will be auto-closed.' },
+}
+
+const needsLabelColor = 'ededed'
+
+/**
+ * desiredLabels lists every label the prow configuration describes, with the
+ * color and description the label-sync job should give it: the label
+ * sections (prefixed `<key>/<value>`, the `/label` allowlist verbatim), the
+ * built-in `/lifecycle`, `/stage` and `/status` values where the yaml has no
+ * section, the labels the action's own commands apply, and every
+ * `require_matching_label` missing label. Names are unique
+ * case-insensitively (first definition wins) and sorted.
+ *
+ * @param config - the merged prow configuration
+ */
+export function desiredLabels(config: ProwConfig): LabelValue[] {
+  const registryKeys = new Set(prefixedLabelCommands.map(cmd => cmd.allowlistKey))
+  const labels: LabelValue[] = []
+
+  for (const cmd of prefixedLabelCommands) {
+    const section = sectionFor(config.labels, cmd)
+    if (section) {
+      labels.push(...section.definitions.map(value => prefixed(cmd.prefix, value)))
+    }
+  }
+
+  for (const [key, section] of Object.entries(config.labels)) {
+    if (!registryKeys.has(key)) {
+      labels.push(...section.definitions.map(value => prefixed(key, value)))
+    }
+  }
+
+  const holdLabels = config.hold.label === undefined ? ['hold'] : ['hold', config.hold.label]
+  for (const name of ['lgtm', 'approved', ...holdLabels, 'help wanted', 'good first issue']) {
+    labels.push({ name })
+  }
+  for (const rule of config.require_matching_label) {
+    labels.push({ name: rule.missing_label })
+  }
+
+  const seen = new Set<string>()
+  const unique = labels.filter((label) => {
+    const key = label.name.toLowerCase()
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
+
+  return unique
+    .map(withDefaults)
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function prefixed(prefix: string, value: LabelValue): LabelValue {
+  return prefix === '' ? { ...value } : { ...value, name: `${prefix}/${value.name}` }
+}
+
+// the configuration wins over the built-in defaults; a label with neither gets no color
+function withDefaults(label: LabelValue): LabelValue {
+  const defaults = builtinLabelDefaults[label.name.toLowerCase()]
+    ?? (label.name.toLowerCase().startsWith('needs-') ? { color: needsLabelColor } : {})
+
+  const merged: LabelValue = { name: label.name }
+  const color = label.color ?? defaults.color
+  const description = label.description ?? defaults.description
+  if (color !== undefined) {
+    merged.color = color.toLowerCase()
+  }
+  if (description !== undefined) {
+    merged.description = description
+  }
+  return merged
+}

--- a/src/utils/labeling.ts
+++ b/src/utils/labeling.ts
@@ -60,7 +60,9 @@ export async function getArgumentLabels(
 }
 
 /**
- * labelIssue will label the issue with the labels provided
+ * labelIssue will label the issue with the labels provided. Like Prow, a
+ * label the repository does not have is refused rather than created by
+ * GitHub with a default color.
  *
  * @param octokit - a hydrated github client
  * @param context - the github actions event context
@@ -73,6 +75,8 @@ export async function labelIssue(
   issueNum: number,
   labels: string[],
 ): Promise<void> {
+  await assertLabelsExist(octokit, context, labels)
+
   try {
     await octokit.issues.addLabels({
       ...context.repo,
@@ -82,6 +86,62 @@ export async function labelIssue(
   }
   catch (e) {
     throw new Error(`could not add labels: ${e}`)
+  }
+}
+
+const repoLabelCache = new Map<string, Promise<string[]>>()
+
+/**
+ * repoLabelNames lists the names of every label of the event repository,
+ * memoized per repository for the lifetime of the process.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions event context
+ */
+export function repoLabelNames(octokit: Octokit, context: Context): Promise<string[]> {
+  const key = `${context.repo.owner}/${context.repo.repo}`
+  let pending = repoLabelCache.get(key)
+  if (pending === undefined) {
+    pending = octokit
+      .paginate(octokit.issues.listLabelsForRepo, { ...context.repo, per_page: 100 })
+      .then(labels => labels.map(label => label.name))
+    repoLabelCache.set(key, pending)
+  }
+  return pending
+}
+
+export function resetLabelCache(): void {
+  repoLabelCache.clear()
+}
+
+/**
+ * assertLabelsExist throws, naming every offender, when one of the labels is
+ * not defined in the repository. Names compare case-insensitively.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github actions event context
+ * @param labels - the labels about to be applied
+ */
+export async function assertLabelsExist(
+  octokit: Octokit,
+  context: Context,
+  labels: string[],
+): Promise<void> {
+  let existing: string[]
+  try {
+    existing = await repoLabelNames(octokit, context)
+  }
+  catch (e) {
+    throw new Error(`could not list the repository labels: ${e}`)
+  }
+
+  const known = new Set(existing.map(name => name.toLowerCase()))
+  const missing = labels.filter(label => !known.has(label.toLowerCase()))
+
+  if (missing.length > 0) {
+    throw new Error(
+      `the label(s) ${missing.join(', ')} cannot be applied because the repository doesn't have them. Run the label-sync job or create them.`,
+    )
   }
 }
 


### PR DESCRIPTION
# Description

PR 2 of the org-wide install sequence. Two parts, two commits.

## `feat(labels): refuse to apply labels the repository does not have` — ⚠️ behaviour change
Today `labelIssue` POSTs and GitHub **silently creates** a missing label with a random grey colour. Prow's `label` plugin refuses instead. Now every label write (prefixed, `/label`, `/help`, `/lgtm`, `/hold`) first checks the repo's labels (one paginated GET, memoized per run) and fails with:

> the label(s) `kind/bug` cannot be applied because the repository doesn't have them. Run the label-sync job or create them.

Removal is not gated. **Existing users** whose repos lack a label they use will now see this error instead of a grey label appearing — run `label-sync` once (below) to converge. Case-insensitive match; the label is applied as spelled in the repo.

## `feat: label-sync job creates and updates labels from the prow configuration`
`jobs: label-sync` — **creates and updates, never deletes, never renames.** Updates only fields that differ (colour compared as lowercase hex; a repo description we don't define is never cleared). Continues past individual failures and fails the run at the end listing them (same policy as #142). `dry-run: true` input logs the plan without writing.

**What it syncs** (`desiredLabels`, pure, 12 tests): every `labels.<key>` value as `<key>/<name>` (the `/label` allowlist verbatim); built-in `lifecycle`/`stage`/`status` defaults **unless** the yaml has that section; the action-managed labels — `lgtm`, `hold`, `help wanted`, `good first issue`, `approved` (reserved for the approve work), every `require_matching_label[].missing_label`, and both `hold` **and** `hold.label` when configured (so `/hold` keeps working during a rename). Colours/descriptions: config > Kubernetes' well-known values from `label_sync` > none (GitHub picks). Case-insensitive de-dupe, first definition wins.

**Triggers:** `schedule` as before, plus `workflow_dispatch` and `push` are now routed to jobs, so a repo can run `on: push: paths: ['.github/prow.yaml']`. Dogfood workflow added; this repo's `prow.yaml` gains colours. For the dogfood config the catalogue is 24 labels.

## Testing
- **553 → 584 tests**; coverage 94.6 / 95.2 br / 99.6 fn. Failing-test-first for both parts (red output in commit messages).
- Never-delete pinned with a DELETE observer that must stay `notCalled`; update-only-on-diff; case-only name difference → no write; pagination; one 422 doesn't stop the others; `dry-run` makes no writes.
- Existing assertions changed: `push` is no longer the "unsupported event" example (→ `issues`); bundle request-sequence assertions include the new labels GET. Every add-label test gained a `repoHasLabels([...])` handler — no assertion weakened.
- Bundle harness: label-sync via `workflow_dispatch` against the real `dist/index.js` (exact set of POSTs, one PATCH, zero DELETEs); a missing-label scenario → no POST, exit 1.
- Docs: `cron-jobs.md`, `configuration.md`, `labeling.md`, `commands.md`, README quickstart.

Next: PR 3 (event routing for `issues`/`pull_request` label events, `pull_request_review`, `check_suite`), then `require-matching-label`.
