### PR TITLE
feat: route issues, pull_request_review, check_suite and pull_request_target; only remove lgtm on new commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ jobs:
 
 ## Documentation
 - [Overview](./docs/overview.md)
+- [Events](./docs/events.md)
 - [Commands](./docs/commands.md)
 - [Configuration](./docs/configuration.md)
 - [Labeling](./docs/labeling.md)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
           merge-method: squash
 ```
 
-Prow Github actions also supports removing the lgtm label when a PR is updated
+Prow Github actions also supports removing the lgtm label when new commits are pushed to a PR (the `synchronize` activity type; other types are skipped)
 
 ```yaml
 name: Run Jobs on PR

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -6,9 +6,12 @@ import process from 'node:process'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import issueCommentEvent from '../fixtures/issues/issueCommentEvent.json'
+import issuesLabeledEvent from '../fixtures/issues/issuesLabeledEvent.json'
 import labelFileContents from '../fixtures/labels/labelFileContentsResp.json'
+import checkSuiteCompletedEvent from '../fixtures/pullReq/checkSuiteCompletedEvent.json'
 import pullReqListPulls from '../fixtures/pullReq/pullReqListPulls.json'
 import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
+import pullReqReviewSubmittedEvent from '../fixtures/pullReq/pullReqReviewSubmittedEvent.json'
 import { blobSha, prCommentEvent } from '../utils/ownersFixtures'
 import { start } from './fakeGithub'
 import { bundlePath, runBundle } from './runBundle'
@@ -91,11 +94,25 @@ describe('dist/index.js', () => {
   })
 
   it('logs an error for an unsupported event without failing or calling the api', async () => {
-    const result = await runBundle({ eventName: 'issues', payload: {}, inputs: token, apiUrl: gh.url })
+    const result = await runBundle({ eventName: 'release', payload: {}, inputs: token, apiUrl: gh.url })
 
     expect(result.status).toBe(0)
-    expect(result.stdout).toContain('issues not yet supported')
-    expect(result.errors).toEqual(['issues not yet supported'])
+    expect(result.stdout).toContain('release not yet supported')
+    expect(result.errors).toEqual(['release not yet supported'])
+    expect(gh.requests).toEqual([])
+  })
+
+  it.each([
+    ['issues', issuesLabeledEvent],
+    ['pull_request_review', pullReqReviewSubmittedEvent],
+    ['check_suite', checkSuiteCompletedEvent],
+    ['status', checkSuiteCompletedEvent],
+  ])('%s is routed and exits 0 without calling the api while no handlers are registered', async (eventName, payload) => {
+    const result = await runBundle({ eventName, payload, inputs: token, apiUrl: gh.url })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(result.stdout).not.toContain('not yet supported')
     expect(gh.requests).toEqual([])
   })
 
@@ -515,6 +532,25 @@ describe('dist/index.js', () => {
 
     const result = await runBundle({
       eventName: 'pull_request',
+      payload: { ...pullReqOpenedEvent, action: 'synchronize' },
+      inputs: { ...token, jobs: 'lgtm' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(gh.requests.map(r => `${r.method} ${r.path}`)).toEqual([
+      `GET ${repo}/issues/1`,
+      `DELETE ${repo}/issues/1/labels/lgtm`,
+    ])
+  })
+
+  it('pull_request_target lgtm job removes the lgtm label on a new push', async () => {
+    gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'lgtm' }] } })
+    gh.route('DELETE', `${repo}/issues/1/labels/lgtm`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'pull_request_target',
       payload: { ...pullReqOpenedEvent, action: 'synchronize' },
       inputs: { ...token, jobs: 'lgtm' },
       apiUrl: gh.url,

--- a/__tests__/bundle/bundle.test.ts
+++ b/__tests__/bundle/bundle.test.ts
@@ -515,7 +515,7 @@ describe('dist/index.js', () => {
 
     const result = await runBundle({
       eventName: 'pull_request',
-      payload: pullReqOpenedEvent,
+      payload: { ...pullReqOpenedEvent, action: 'synchronize' },
       inputs: { ...token, jobs: 'lgtm' },
       apiUrl: gh.url,
     })
@@ -526,6 +526,22 @@ describe('dist/index.js', () => {
       `GET ${repo}/issues/1`,
       `DELETE ${repo}/issues/1/labels/lgtm`,
     ])
+  })
+
+  it('pull_request lgtm job leaves the lgtm label alone when the pr is labeled', async () => {
+    gh.route('GET', `${repo}/issues/1`, { status: 200, body: { labels: [{ name: 'lgtm' }] } })
+    gh.route('DELETE', `${repo}/issues/1/labels/lgtm`, { status: 200, body: [] })
+
+    const result = await runBundle({
+      eventName: 'pull_request',
+      payload: { ...pullReqOpenedEvent, action: 'labeled', label: { name: 'lgtm' } },
+      inputs: { ...token, jobs: 'lgtm' },
+      apiUrl: gh.url,
+    })
+
+    expect(result.status, result.stdout).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(gh.requests).toEqual([])
   })
 
   describe('schedule lgtm job', () => {

--- a/__tests__/fixtures/issues/issuesLabeledEvent.json
+++ b/__tests__/fixtures/issues/issuesLabeledEvent.json
@@ -1,0 +1,124 @@
+{
+  "action": "labeled",
+  "issue": {
+    "url": "https://api.github.com/repos/Codertocat/Hello-World/issues/1",
+    "html_url": "https://github.com/Codertocat/Hello-World/issues/1",
+    "id": 444500041,
+    "node_id": "MDU6SXNzdWU0NDQ1MDAwNDE=",
+    "number": 1,
+    "title": "Spelling error in the README file",
+    "state": "open",
+    "locked": false,
+    "body": "It looks like you accidently spelled 'commit' with two 't's.",
+    "labels": [
+      {
+        "id": 4797,
+        "node_id": "MDU6TGFiZWw0Nzk3",
+        "name": "kind/bug",
+        "color": "d73a4a",
+        "default": false,
+        "description": "Something isn't working"
+      }
+    ],
+    "assignees": [
+      {
+        "login": "Codertocat",
+        "id": 21031067,
+        "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+        "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Codertocat",
+        "html_url": "https://github.com/Codertocat",
+        "followers_url": "https://api.github.com/users/Codertocat/followers",
+        "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+        "repos_url": "https://api.github.com/users/Codertocat/repos",
+        "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+        "type": "User",
+        "site_admin": false
+      }
+    ],
+    "milestone": {
+      "url": "https://api.github.com/repos/Codertocat/Hello-World/milestones/1",
+      "html_url": "https://github.com/Codertocat/Hello-World/milestone/1",
+      "labels_url": "https://api.github.com/repos/Codertocat/Hello-World/milestones/1/labels",
+      "id": 4317517,
+      "node_id": "MDk6TWlsZXN0b25lNDMxNzUxNw==",
+      "number": 1,
+      "title": "v1.0",
+      "description": "Add new space flight simulator",
+      "creator": {
+        "login": "Codertocat",
+        "id": 21031067,
+        "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+        "avatar_url": "https://avatars1.githubusercontent.com/u/21031067?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/Codertocat",
+        "html_url": "https://github.com/Codertocat",
+        "followers_url": "https://api.github.com/users/Codertocat/followers",
+        "following_url": "https://api.github.com/users/Codertocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/Codertocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/Codertocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/Codertocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/Codertocat/orgs",
+        "repos_url": "https://api.github.com/users/Codertocat/repos",
+        "events_url": "https://api.github.com/users/Codertocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/Codertocat/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "open_issues": 1,
+      "closed_issues": 0,
+      "state": "closed",
+      "created_at": "2019-05-15T15:20:17Z",
+      "updated_at": "2019-05-15T15:20:18Z",
+      "due_on": "2019-05-23T07:00:00Z",
+      "closed_at": "2019-05-15T15:20:18Z"
+    },
+    "user": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    }
+  },
+  "label": {
+    "id": 4797,
+    "node_id": "MDU6TGFiZWw0Nzk3",
+    "name": "kind/bug",
+    "color": "d73a4a",
+    "default": false,
+    "description": "Something isn't working"
+  },
+  "repository": {
+    "id": 186853002,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=",
+    "name": "Hello-World",
+    "full_name": "Codertocat/Hello-World",
+    "private": false,
+    "html_url": "https://github.com/Codertocat/Hello-World",
+    "default_branch": "master",
+    "owner": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    }
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "html_url": "https://github.com/Codertocat",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/__tests__/fixtures/pullReq/checkSuiteCompletedEvent.json
+++ b/__tests__/fixtures/pullReq/checkSuiteCompletedEvent.json
@@ -1,0 +1,44 @@
+{
+  "action": "completed",
+  "check_suite": {
+    "id": 118578147,
+    "node_id": "MDEwOkNoZWNrU3VpdGUxMTg1NzgxNDc=",
+    "head_branch": "changes",
+    "head_sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+    "status": "completed",
+    "conclusion": "success",
+    "before": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e",
+    "after": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+    "pull_requests": [],
+    "app": {
+      "id": 29310,
+      "slug": "octocoders-linter",
+      "name": "octocoders-linter"
+    }
+  },
+  "repository": {
+    "id": 186853002,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=",
+    "name": "Hello-World",
+    "full_name": "Codertocat/Hello-World",
+    "private": false,
+    "html_url": "https://github.com/Codertocat/Hello-World",
+    "default_branch": "master",
+    "owner": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    }
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "html_url": "https://github.com/Codertocat",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/__tests__/fixtures/pullReq/pullReqReviewSubmittedEvent.json
+++ b/__tests__/fixtures/pullReq/pullReqReviewSubmittedEvent.json
@@ -1,0 +1,77 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 237895671,
+    "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjM3ODk1Njcx",
+    "user": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": null,
+    "state": "approved",
+    "html_url": "https://github.com/Codertocat/Hello-World/pull/2#pullrequestreview-237895671",
+    "commit_id": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+    "submitted_at": "2019-05-15T15:20:38Z",
+    "author_association": "OWNER"
+  },
+  "pull_request": {
+    "url": "https://api.github.com/repos/Codertocat/Hello-World/pulls/1",
+    "html_url": "https://github.com/Codertocat/Hello-World/pull/2",
+    "id": 279147437,
+    "node_id": "MDExOlB1bGxSZXF1ZXN0Mjc5MTQ3NDM3",
+    "number": 1,
+    "state": "open",
+    "locked": false,
+    "title": "Update the README with new information.",
+    "body": "This is a pretty simple change that we need to pull into master.",
+    "draft": false,
+    "labels": [],
+    "user": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    },
+    "head": {
+      "label": "Codertocat:changes",
+      "ref": "changes",
+      "sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
+    },
+    "base": {
+      "label": "Codertocat:master",
+      "ref": "master",
+      "sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e"
+    }
+  },
+  "repository": {
+    "id": 186853002,
+    "node_id": "MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=",
+    "name": "Hello-World",
+    "full_name": "Codertocat/Hello-World",
+    "private": false,
+    "html_url": "https://github.com/Codertocat/Hello-World",
+    "default_branch": "master",
+    "owner": {
+      "login": "Codertocat",
+      "id": 21031067,
+      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+      "html_url": "https://github.com/Codertocat",
+      "type": "User",
+      "site_admin": false
+    }
+  },
+  "sender": {
+    "login": "Codertocat",
+    "id": 21031067,
+    "node_id": "MDQ6VXNlcjIxMDMxMDY3",
+    "html_url": "https://github.com/Codertocat",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/__tests__/issuesTest/handleIssues.test.ts
+++ b/__tests__/issuesTest/handleIssues.test.ts
@@ -1,0 +1,65 @@
+import * as core from '@actions/core'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleIssues, issueEventHandlers } from '../../src/issues/handleIssues'
+import issuesLabeledEvent from '../fixtures/issues/issuesLabeledEvent.json'
+import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => {
+  server.resetHandlers()
+  issueEventHandlers.length = 0
+})
+afterAll(() => server.close())
+
+describe('handleIssues', () => {
+  beforeEach(() => {
+    utils.setupActionsEnv()
+  })
+
+  it('resolves without calling the api or failing when no handlers are registered', async () => {
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const debug = vi.spyOn(core, 'debug').mockImplementation(() => {})
+
+    await expect(handleIssues(new utils.MockContext(issuesLabeledEvent))).resolves.toBeUndefined()
+
+    expect(setFailed).not.toHaveBeenCalled()
+    expect(debug).toHaveBeenCalledWith('issues event labeled received; no handlers registered yet')
+  })
+
+  it('runs every registered handler with the context', async () => {
+    const first = vi.fn().mockResolvedValue(undefined)
+    const second = vi.fn().mockResolvedValue(undefined)
+    issueEventHandlers.push(first, second)
+    const context = new utils.MockContext(issuesLabeledEvent)
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleIssues(context)
+
+    expect(first).toHaveBeenCalledWith(context)
+    expect(second).toHaveBeenCalledWith(context)
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails once with every rejection and still runs the other handlers', async () => {
+    const ok = vi.fn().mockResolvedValue(undefined)
+    issueEventHandlers.push(
+      vi.fn().mockRejectedValue(new Error('first boom')),
+      ok,
+      vi.fn().mockRejectedValue('second boom'),
+    )
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await expect(handleIssues(new utils.MockContext(issuesLabeledEvent))).resolves.toBeUndefined()
+
+    expect(ok).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith('error handling issues event: first boom; second boom')
+  })
+})

--- a/__tests__/pullReqTest/handleCheckSuite.test.ts
+++ b/__tests__/pullReqTest/handleCheckSuite.test.ts
@@ -1,0 +1,113 @@
+import * as core from '@actions/core'
+import { http } from 'msw'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { checkSuiteHandlers, handleCheckSuite, pullRequestsForSha } from '../../src/pullReq/handleCheckSuite'
+import { newOctokit } from '../../src/utils/octokit'
+import checkSuiteCompletedEvent from '../fixtures/pullReq/checkSuiteCompletedEvent.json'
+import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => {
+  server.resetHandlers()
+  checkSuiteHandlers.length = 0
+})
+afterAll(() => server.close())
+
+const sha = checkSuiteCompletedEvent.check_suite.head_sha
+
+describe('handleCheckSuite', () => {
+  beforeEach(() => {
+    utils.setupActionsEnv()
+  })
+
+  it.each(['check_suite', 'status'])('resolves a %s event without calling the api or failing when no handlers are registered', async (eventName) => {
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    context.eventName = eventName
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const debug = vi.spyOn(core, 'debug').mockImplementation(() => {})
+
+    await expect(handleCheckSuite(context)).resolves.toBeUndefined()
+
+    expect(setFailed).not.toHaveBeenCalled()
+    expect(debug).toHaveBeenCalledWith(`${eventName} event completed received; no handlers registered yet`)
+  })
+
+  it('runs every registered handler with the context', async () => {
+    const first = vi.fn().mockResolvedValue(undefined)
+    const second = vi.fn().mockResolvedValue(undefined)
+    checkSuiteHandlers.push(first, second)
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    context.eventName = 'check_suite'
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handleCheckSuite(context)
+
+    expect(first).toHaveBeenCalledWith(context)
+    expect(second).toHaveBeenCalledWith(context)
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails once with the aggregated rejection message', async () => {
+    checkSuiteHandlers.push(vi.fn().mockRejectedValue(new Error('suite boom')))
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    context.eventName = 'check_suite'
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await expect(handleCheckSuite(context)).resolves.toBeUndefined()
+
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith('error handling check_suite event: suite boom')
+  })
+})
+
+describe('pullRequestsForSha', () => {
+  function servePages(pages: { number: number, sha: string }[][]) {
+    const seen: string[] = []
+    server.use(
+      http.get(`${utils.api}/repos/Codertocat/Hello-World/pulls`, ({ request }) => {
+        const url = new URL(request.url)
+        seen.push(url.search)
+        const page = Number(url.searchParams.get('page'))
+        const body = (pages[page - 1] ?? []).map(pr => ({ number: pr.number, head: { sha: pr.sha } }))
+        return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }),
+    )
+    return seen
+  }
+
+  it('returns the numbers of the open prs whose head is the sha across pages', async () => {
+    const seen = servePages([
+      [{ number: 2, sha }, { number: 3, sha: 'other' }],
+      [{ number: 5, sha }],
+    ])
+
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    await expect(pullRequestsForSha(newOctokit('some-token'), context, sha)).resolves.toEqual([2, 5])
+    expect(seen).toEqual([
+      '?state=open&per_page=100&page=1',
+      '?state=open&per_page=100&page=2',
+      '?state=open&per_page=100&page=3',
+    ])
+  })
+
+  it('returns an empty list when no open pr has the sha', async () => {
+    servePages([[{ number: 2, sha: 'other' }]])
+
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    await expect(pullRequestsForSha(newOctokit('some-token'), context, sha)).resolves.toEqual([])
+  })
+
+  it('returns an empty list when the repository has no open prs', async () => {
+    servePages([])
+
+    const context = new utils.MockContext(checkSuiteCompletedEvent)
+    await expect(pullRequestsForSha(newOctokit('some-token'), context, sha)).resolves.toEqual([])
+  })
+})

--- a/__tests__/pullReqTest/handlePullReq.test.ts
+++ b/__tests__/pullReqTest/handlePullReq.test.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import { http } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest'
-import { handlePullReq } from '../../src/pullReq/handlePullReq'
+import { handlePullReq, pullRequestHandlers } from '../../src/pullReq/handlePullReq'
 
 import issuePayload from '../fixtures/issues/issue.json'
 import prOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
@@ -15,7 +15,10 @@ beforeAll(() =>
     onUnhandledRequest: 'error',
   }),
 )
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  pullRequestHandlers.length = 0
+})
 afterAll(() => server.close())
 
 // the lgtm PR job only acts on new commits; the fixture is an `opened` event
@@ -113,4 +116,26 @@ it('still fails on an unknown job name when the lgtm job is skipped', async () =
   expect(setFailed).toHaveBeenCalledWith(
     expect.stringContaining('could not execute pr-labeler'),
   )
+})
+
+it('runs the registered pull_request handlers before the jobs', async () => {
+  utils.setupJobsEnv('lgtm')
+  const runContext = new utils.MockContext({ ...prOpenedEvent, action: 'labeled' })
+  const handler = vi.fn().mockResolvedValue(undefined)
+  pullRequestHandlers.push(handler)
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  expect(handler).toHaveBeenCalledWith(runContext)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+it('fails the run when a registered pull_request handler rejects', async () => {
+  utils.setupJobsEnv('lgtm')
+  const runContext = new utils.MockContext({ ...prOpenedEvent, action: 'labeled' })
+  pullRequestHandlers.push(vi.fn().mockRejectedValue(new Error('plugin boom')))
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  expect(setFailed).toHaveBeenCalledWith('error handling pull_request event: plugin boom')
 })

--- a/__tests__/pullReqTest/handlePullReq.test.ts
+++ b/__tests__/pullReqTest/handlePullReq.test.ts
@@ -5,7 +5,7 @@ import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest'
 import { handlePullReq } from '../../src/pullReq/handlePullReq'
 
 import issuePayload from '../fixtures/issues/issue.json'
-import prCreatedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
+import prOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 
 import * as utils from '../testUtils'
 
@@ -18,13 +18,17 @@ beforeAll(() =>
 afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
+// the lgtm PR job only acts on new commits; the fixture is an `opened` event
+const prSynchronizeEvent = { ...prOpenedEvent, action: 'synchronize' }
+
 function serveLgtmRemoval() {
   const payload = structuredClone(issuePayload)
   payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+  const getReq = new utils.ObserveRequest()
   server.use(
     http.get(
       `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
-      utils.mockResponse(200, payload),
+      utils.mockResponse(200, payload, getReq),
     ),
   )
   const deleteReq = new utils.ObserveRequest()
@@ -34,7 +38,7 @@ function serveLgtmRemoval() {
       utils.mockResponse(200, null, deleteReq),
     ),
   )
-  return deleteReq
+  return { getReq, deleteReq }
 }
 
 it('ignores the jobs if not setup in environment', async () => {
@@ -42,7 +46,7 @@ it('ignores the jobs if not setup in environment', async () => {
 
   utils.setupActionsEnv('/assign')
 
-  const runContext = new utils.MockContext(prCreatedEvent)
+  const runContext = new utils.MockContext(prSynchronizeEvent)
 
   await handlePullReq(runContext)
   expect(spy).toHaveBeenCalled()
@@ -50,8 +54,8 @@ it('ignores the jobs if not setup in environment', async () => {
 
 it('dispatches jobs delimited by newlines', async () => {
   utils.setupJobsEnv('lgtm\n')
-  const runContext = new utils.MockContext(prCreatedEvent)
-  const deleteReq = serveLgtmRemoval()
+  const runContext = new utils.MockContext(prSynchronizeEvent)
+  const { deleteReq } = serveLgtmRemoval()
 
   const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
   await expect(handlePullReq(runContext)).resolves.toBeUndefined()
@@ -61,8 +65,8 @@ it('dispatches jobs delimited by newlines', async () => {
 
 it('dispatches jobs delimited by newlines and extra spaces', async () => {
   utils.setupJobsEnv('lgtm  pr-labeler\n')
-  const runContext = new utils.MockContext(prCreatedEvent)
-  const deleteReq = serveLgtmRemoval()
+  const runContext = new utils.MockContext(prSynchronizeEvent)
+  const { deleteReq } = serveLgtmRemoval()
 
   const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
   await expect(handlePullReq(runContext)).resolves.toBeUndefined()
@@ -74,11 +78,39 @@ it('dispatches jobs delimited by newlines and extra spaces', async () => {
 
 it('matches job names case-insensitively', async () => {
   utils.setupJobsEnv('LGTM')
-  const runContext = new utils.MockContext(prCreatedEvent)
-  const deleteReq = serveLgtmRemoval()
+  const runContext = new utils.MockContext(prSynchronizeEvent)
+  const { deleteReq } = serveLgtmRemoval()
 
   const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
   await expect(handlePullReq(runContext)).resolves.toBeUndefined()
   await expect(deleteReq.called()).resolves.toBe('called')
   expect(setFailed).not.toHaveBeenCalled()
+})
+
+it.each(['opened', 'reopened', 'labeled', 'unlabeled', 'ready_for_review', 'edited', 'closed'])(
+  'lgtm job does not touch the pr on a %s action',
+  async (action) => {
+    utils.setupJobsEnv('lgtm')
+    const runContext = new utils.MockContext({ ...prOpenedEvent, action })
+    const { getReq, deleteReq } = serveLgtmRemoval()
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+    await expect(deleteReq.notCalled()).resolves.toBe('not called')
+    expect(getReq.ref).toBeNull()
+    expect(setFailed).not.toHaveBeenCalled()
+  },
+)
+
+it('still fails on an unknown job name when the lgtm job is skipped', async () => {
+  utils.setupJobsEnv('lgtm pr-labeler')
+  const runContext = new utils.MockContext({ ...prOpenedEvent, action: 'labeled' })
+  const { deleteReq } = serveLgtmRemoval()
+
+  const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+  await expect(handlePullReq(runContext)).resolves.toBeUndefined()
+  await expect(deleteReq.notCalled()).resolves.toBe('not called')
+  expect(setFailed).toHaveBeenCalledWith(
+    expect.stringContaining('could not execute pr-labeler'),
+  )
 })

--- a/__tests__/pullReqTest/handlePullReqReview.test.ts
+++ b/__tests__/pullReqTest/handlePullReqReview.test.ts
@@ -1,0 +1,59 @@
+import * as core from '@actions/core'
+import { setupServer } from 'msw/node'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handlePullReqReview, pullRequestReviewHandlers } from '../../src/pullReq/handlePullReqReview'
+import reviewSubmittedEvent from '../fixtures/pullReq/pullReqReviewSubmittedEvent.json'
+import * as utils from '../testUtils'
+
+const server = setupServer()
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest: 'error',
+  }),
+)
+afterEach(() => {
+  server.resetHandlers()
+  pullRequestReviewHandlers.length = 0
+})
+afterAll(() => server.close())
+
+describe('handlePullReqReview', () => {
+  beforeEach(() => {
+    utils.setupActionsEnv()
+  })
+
+  it('resolves without calling the api or failing when no handlers are registered', async () => {
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    const debug = vi.spyOn(core, 'debug').mockImplementation(() => {})
+
+    await expect(handlePullReqReview(new utils.MockContext(reviewSubmittedEvent))).resolves.toBeUndefined()
+
+    expect(setFailed).not.toHaveBeenCalled()
+    expect(debug).toHaveBeenCalledWith('pull_request_review event submitted received; no handlers registered yet')
+  })
+
+  it('runs every registered handler with the context', async () => {
+    const first = vi.fn().mockResolvedValue(undefined)
+    const second = vi.fn().mockResolvedValue(undefined)
+    pullRequestReviewHandlers.push(first, second)
+    const context = new utils.MockContext(reviewSubmittedEvent)
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await handlePullReqReview(context)
+
+    expect(first).toHaveBeenCalledWith(context)
+    expect(second).toHaveBeenCalledWith(context)
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it('fails once with the aggregated rejection message', async () => {
+    pullRequestReviewHandlers.push(vi.fn().mockRejectedValue(new Error('review boom')))
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+
+    await expect(handlePullReqReview(new utils.MockContext(reviewSubmittedEvent))).resolves.toBeUndefined()
+
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(setFailed).toHaveBeenCalledWith('error handling pull_request_review event: review boom')
+  })
+})

--- a/__tests__/pullReqTest/onPrLgtm.test.ts
+++ b/__tests__/pullReqTest/onPrLgtm.test.ts
@@ -6,8 +6,11 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { handlePullReq } from '../../src/pullReq/handlePullReq'
 import issuePayload from '../fixtures/issues/issue.json'
 
-import pullReqEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
+import pullReqOpenedEvent from '../fixtures/pullReq/pullReqOpenedEvent.json'
 import * as utils from '../testUtils'
+
+// removal is tied to new commits, so the cases below run on `synchronize`
+const pullReqEvent = { ...pullReqOpenedEvent, action: 'synchronize' }
 
 const server = setupServer()
 beforeAll(() =>
@@ -61,6 +64,30 @@ describe('onPrLgtm', () => {
       http.get(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
         utils.mockResponse(200, issuePayload),
+      ),
+      http.delete(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,
+        utils.mockResponse(200, null, observeReq),
+      ),
+    )
+
+    const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
+    await expect(handlePullReq(prContext)).resolves.not.toThrow()
+    await expect(observeReq.notCalled()).resolves.toBe('not called')
+    expect(setFailed).not.toHaveBeenCalled()
+  })
+
+  it.each(['opened', 'labeled', 'unlabeled'])('leaves lgtm in place on a %s action', async (action) => {
+    const prContext = new utils.MockContext({ ...pullReqOpenedEvent, action })
+
+    const payload = structuredClone(issuePayload)
+    payload.labels.push({ ...payload.labels[0], name: 'lgtm' })
+
+    const observeReq = new utils.ObserveRequest()
+    server.use(
+      http.get(
+        `${utils.api}/repos/Codertocat/Hello-World/issues/1`,
+        utils.mockResponse(200, payload),
       ),
       http.delete(
         `${utils.api}/repos/Codertocat/Hello-World/issues/1/labels/lgtm`,

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -5,14 +5,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { handleCronJobs } from '../src/cronJobs/handleCronJob'
 import { handleIssueComment } from '../src/issueComment/handleIssueComment'
+import { handleIssues } from '../src/issues/handleIssues'
+import { handleCheckSuite } from '../src/pullReq/handleCheckSuite'
 import { handlePullReq } from '../src/pullReq/handlePullReq'
+import { handlePullReqReview } from '../src/pullReq/handlePullReqReview'
 import { run } from '../src/run'
 
 vi.mock('../src/issueComment/handleIssueComment', () => ({
   handleIssueComment: vi.fn(),
 }))
+vi.mock('../src/issues/handleIssues', () => ({
+  handleIssues: vi.fn(),
+}))
 vi.mock('../src/pullReq/handlePullReq', () => ({
   handlePullReq: vi.fn(),
+}))
+vi.mock('../src/pullReq/handlePullReqReview', () => ({
+  handlePullReqReview: vi.fn(),
+}))
+vi.mock('../src/pullReq/handleCheckSuite', () => ({
+  handleCheckSuite: vi.fn(),
 }))
 vi.mock('../src/cronJobs/handleCronJob', () => ({
   handleCronJobs: vi.fn(),
@@ -23,6 +35,29 @@ const mockedHandle = handleIssueComment as MockedFunction<
 >
 const mockedHandlePullReq = handlePullReq as MockedFunction<typeof handlePullReq>
 const mockedHandleCronJobs = handleCronJobs as MockedFunction<typeof handleCronJobs>
+
+const handlers = {
+  handleIssueComment: mockedHandle,
+  handleIssues: handleIssues as MockedFunction<typeof handleIssues>,
+  handlePullReq: mockedHandlePullReq,
+  handlePullReqReview: handlePullReqReview as MockedFunction<typeof handlePullReqReview>,
+  handleCheckSuite: handleCheckSuite as MockedFunction<typeof handleCheckSuite>,
+  handleCronJobs: mockedHandleCronJobs,
+}
+type HandlerName = keyof typeof handlers
+
+const dispatchTable: [string, HandlerName][] = [
+  ['issue_comment', 'handleIssueComment'],
+  ['issues', 'handleIssues'],
+  ['pull_request', 'handlePullReq'],
+  ['pull_request_target', 'handlePullReq'],
+  ['pull_request_review', 'handlePullReqReview'],
+  ['check_suite', 'handleCheckSuite'],
+  ['status', 'handleCheckSuite'],
+  ['schedule', 'handleCronJobs'],
+  ['workflow_dispatch', 'handleCronJobs'],
+  ['push', 'handleCronJobs'],
+]
 
 describe('run', () => {
   beforeEach(() => {
@@ -52,61 +87,33 @@ describe('run', () => {
     expect(resolved).toBe(true)
   })
 
-  it('dispatches issue_comment to handleIssueComment', async () => {
-    mockedHandle.mockResolvedValue()
-
-    await run()
-
-    expect(mockedHandle).toHaveBeenCalledTimes(1)
-    expect(mockedHandlePullReq).not.toHaveBeenCalled()
-    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
-  })
-
-  it('dispatches pull_request to handlePullReq', async () => {
-    github.context.eventName = 'pull_request'
-    mockedHandlePullReq.mockResolvedValue()
-
-    await run()
-
-    expect(mockedHandlePullReq).toHaveBeenCalledTimes(1)
-    expect(mockedHandle).not.toHaveBeenCalled()
-    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
-  })
-
-  it('dispatches schedule to handleCronJobs', async () => {
-    github.context.eventName = 'schedule'
-    mockedHandleCronJobs.mockResolvedValue()
-
-    await run()
-
-    expect(mockedHandleCronJobs).toHaveBeenCalledTimes(1)
-    expect(mockedHandle).not.toHaveBeenCalled()
-    expect(mockedHandlePullReq).not.toHaveBeenCalled()
-  })
-
-  it.each(['workflow_dispatch', 'push'])('dispatches %s to handleCronJobs', async (eventName) => {
+  it.each(dispatchTable)('dispatches %s to %s with the github context', async (eventName, handlerName) => {
     github.context.eventName = eventName
-    mockedHandleCronJobs.mockResolvedValue()
+    handlers[handlerName].mockResolvedValue()
 
     await run()
 
-    expect(mockedHandleCronJobs).toHaveBeenCalledTimes(1)
-    expect(mockedHandle).not.toHaveBeenCalled()
-    expect(mockedHandlePullReq).not.toHaveBeenCalled()
+    expect(handlers[handlerName]).toHaveBeenCalledTimes(1)
+    expect(handlers[handlerName]).toHaveBeenCalledWith(github.context)
+    for (const [name, handler] of Object.entries(handlers)) {
+      if (name !== handlerName) {
+        expect(handler, name).not.toHaveBeenCalled()
+      }
+    }
   })
 
-  it('logs an error for an unsupported event without failing', async () => {
-    github.context.eventName = 'issues'
+  it.each(['release', 'toString', 'constructor'])('logs an error for the unsupported event %s without failing', async (eventName) => {
+    github.context.eventName = eventName
     const logError = vi.spyOn(core, 'error').mockImplementation(() => {})
     const setFailed = vi.spyOn(core, 'setFailed').mockImplementation(() => {})
 
     await expect(run()).resolves.toBeUndefined()
 
-    expect(logError).toHaveBeenCalledWith('issues not yet supported')
+    expect(logError).toHaveBeenCalledWith(`${eventName} not yet supported`)
     expect(setFailed).not.toHaveBeenCalled()
-    expect(mockedHandle).not.toHaveBeenCalled()
-    expect(mockedHandlePullReq).not.toHaveBeenCalled()
-    expect(mockedHandleCronJobs).not.toHaveBeenCalled()
+    for (const handler of Object.values(handlers)) {
+      expect(handler).not.toHaveBeenCalled()
+    }
   })
 
   it('reports a dispatched handler rejection through setFailed', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -43724,11 +43724,13 @@ async function onPrLgtm(context) {
 
 /**
  * This method handles any pull-request configuration for configured workflows.
- * At this time, there are no commands for prow-github-actions
+ * The `lgtm` job only acts on `synchronize` (new commits); every other
+ * activity type is logged and skipped.
  *
  * @param context - the github context of the current action event
  */
 async function handlePullReq(context = github_context) {
+    const action = context.payload.action;
     const runConfig = getInput('jobs', { required: false })
         .split(/\s+/)
         .filter(command => command !== '')
@@ -43740,6 +43742,10 @@ async function handlePullReq(context = github_context) {
         core_debug(`${context}`);
         switch (command) {
             case 'lgtm':
+                if (action !== 'synchronize') {
+                    core_debug(`skipping pr lgtm job: ${action} pushes no new commits`);
+                    return;
+                }
                 core_debug('running pr lgtm new commit job');
                 return await onPrLgtm(context).catch(async (e) => {
                     return e;

--- a/dist/index.js
+++ b/dist/index.js
@@ -43689,6 +43689,80 @@ function normalizeError(error) {
     return error instanceof Error ? error : new Error(String(error));
 }
 
+;// CONCATENATED MODULE: ./lib/utils/events.js
+
+/**
+ * Runs every registered handler for an event and fails the run once with the
+ * collected rejections. An empty registry is a debug-logged no-op.
+ *
+ * @param event - the github event name
+ * @param handlers - the registry to run
+ * @param context - the github context of the current action event
+ */
+async function runEventHandlers(event, handlers, context) {
+    const action = context.payload.action;
+    if (handlers.length === 0) {
+        core_debug(`${event} event ${action} received; no handlers registered yet`);
+        return;
+    }
+    const results = await Promise.all(handlers.map(handler => handler(context).catch((e) => (e instanceof Error ? e : new Error(String(e))))));
+    const errors = results.filter((result) => result instanceof Error);
+    if (errors.length > 0) {
+        setFailed(`error handling ${event} event: ${errors.map(e => e.message).join('; ')}`);
+    }
+}
+
+;// CONCATENATED MODULE: ./lib/issues/handleIssues.js
+
+
+/** handlers that run on every `issues` event; empty until require-matching-label lands */
+const issueEventHandlers = [];
+/**
+ * Dispatches an `issues` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+async function handleIssues(context = github_context) {
+    await runEventHandlers('issues', issueEventHandlers, context);
+}
+
+;// CONCATENATED MODULE: ./lib/pullReq/handleCheckSuite.js
+
+
+/** handlers that run on every `check_suite` and `status` event; empty until event-driven merging lands */
+const checkSuiteHandlers = [];
+/**
+ * Dispatches a `check_suite` or legacy commit `status` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+async function handleCheckSuite(context = github_context) {
+    await runEventHandlers(context.eventName, checkSuiteHandlers, context);
+}
+/**
+ * Lists the numbers of the open pull requests whose head is the given commit,
+ * paging through `pulls.list` until a page comes back empty.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github context of the current action event
+ * @param sha - the head commit to look up
+ */
+async function pullRequestsForSha(octokit, context, sha) {
+    const numbers = [];
+    for (let page = 1;; page++) {
+        const { data } = await octokit.pulls.list({
+            ...context.repo,
+            state: 'open',
+            per_page: 100,
+            page,
+        });
+        if (data.length === 0) {
+            return numbers;
+        }
+        numbers.push(...data.filter(pr => pr.head.sha === sha).map(pr => pr.number));
+    }
+}
+
 ;// CONCATENATED MODULE: ./lib/pullReq/onPrLgtm.js
 
 
@@ -43722,10 +43796,13 @@ async function onPrLgtm(context) {
 
 
 
+
+/** handlers that run on every `pull_request` / `pull_request_target` event, next to the `jobs` input; empty for now */
+const pullRequestHandlers = [];
 /**
- * This method handles any pull-request configuration for configured workflows.
- * The `lgtm` job only acts on `synchronize` (new commits); every other
- * activity type is logged and skipped.
+ * This method handles any pull-request configuration for configured workflows:
+ * the registered handlers and the `jobs` input. The `lgtm` job only acts on
+ * `synchronize` (new commits); every other activity type is logged and skipped.
  *
  * @param context - the github context of the current action event
  */
@@ -43738,6 +43815,7 @@ async function handlePullReq(context = github_context) {
     if (runConfig.length === 0) {
         runConfig.push('');
     }
+    await runEventHandlers('pull_request', pullRequestHandlers, context);
     await Promise.all(runConfig.map(async (command) => {
         core_debug(`${context}`);
         switch (command) {
@@ -43768,30 +43846,52 @@ async function handlePullReq(context = github_context) {
     });
 }
 
+;// CONCATENATED MODULE: ./lib/pullReq/handlePullReqReview.js
+
+
+/** handlers that run on every `pull_request_review` event; empty for now */
+const pullRequestReviewHandlers = [];
+/**
+ * Dispatches a `pull_request_review` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+async function handlePullReqReview(context = github_context) {
+    await runEventHandlers('pull_request_review', pullRequestReviewHandlers, context);
+}
+
 ;// CONCATENATED MODULE: ./lib/run.js
 
 
 
 
 
+
+
+
+// one row per github event; pull_request_target shares the pull_request payload,
+// status is the legacy commit status that check_suite superseded
+const eventHandlers = {
+    issue_comment: handleIssueComment,
+    issues: handleIssues,
+    pull_request: handlePullReq,
+    pull_request_target: handlePullReq,
+    pull_request_review: handlePullReqReview,
+    check_suite: handleCheckSuite,
+    status: handleCheckSuite,
+    schedule: handleCronJobs,
+    workflow_dispatch: handleCronJobs,
+    push: handleCronJobs,
+};
 async function run() {
     try {
-        switch (github_context.eventName) {
-            case 'issue_comment':
-                await handleIssueComment();
-                break;
-            case 'pull_request':
-                await handlePullReq();
-                break;
-            case 'schedule':
-            case 'workflow_dispatch':
-            case 'push':
-                await handleCronJobs();
-                break;
-            default:
-                error(`${github_context.eventName} not yet supported`);
-                break;
+        const context = github_context;
+        const handler = Object.hasOwn(eventHandlers, context.eventName) ? eventHandlers[context.eventName] : undefined;
+        if (!handler) {
+            error(`${context.eventName} not yet supported`);
+            return;
         }
+        await handler(context);
     }
     catch (error) {
         setFailed(error instanceof Error ? error.message : String(error));

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -1,7 +1,7 @@
 # Jobs
 
 Jobs run from the `jobs` input on `schedule`, `workflow_dispatch` and `push` events
-(`pull_request` runs the [PR jobs](./pr-jobs.md)). The input is space or newline
+(`pull_request` and `pull_request_target` run the [PR jobs](./pr-jobs.md)). The input is space or newline
 delimited and case-insensitive (`jobs: lgtm label-sync`). Every listed job runs; an
 unknown name fails the run with `could not execute <job>`.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,55 @@
+# Events
+
+The action reads `GITHUB_EVENT_NAME` and routes the event to one handler. An event
+that is not in the table logs `<event> not yet supported` as an error annotation and
+exits 0 without calling the API.
+
+## Handled today
+
+Event | Input | Does
+--- | --- | ---
+`issue_comment` | `prow-commands` | Runs the [`/commands`](./commands.md) found in the comment.
+`pull_request` | `jobs` | Runs the [PR jobs](./pr-jobs.md); `lgtm` acts on `synchronize` only.
+`pull_request_target` | `jobs` | Same as `pull_request` with a write token on fork PRs. Read the [safety rule](./pr-jobs.md#pull_request_target) first.
+`schedule`, `workflow_dispatch`, `push` | `jobs` | Runs the [jobs](./cron-jobs.md) (`lgtm` merger, `label-sync`).
+
+## Routed, no handlers yet
+
+Event | Why it is routed
+--- | ---
+`issues` | label and lifecycle policy on issues
+`pull_request_review` | review-driven labels
+`check_suite`, `status` | merging when checks finish (`status` is the legacy commit status API; PRs are looked up by head sha)
+
+These exit 0 and make no API calls. Handlers arrive with require-matching-label,
+owners-label and event-driven merging in later releases.
+
+Subscribing early is harmless and lets the workflow file stay put when the handlers land:
+
+```yaml
+name: Prow github actions
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          prow-commands: /lgtm /approve /hold /kind /area /priority
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,9 +10,11 @@ This is achieved through utilizing Github actions CI/CD system
 and removes much of the overhead and infrastructure needed for running the Prow bot.
 
 Workflows are broken down into commands and jobs
-that can be run with specific [Github "events"](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)
+that can be run with specific [Github "events"](https://docs.github.com/en/actions/reference/events-that-trigger-workflows);
+[events](./events.md) lists which ones the action routes.
 
 ## Read more
+- [Events the action routes](./events.md)
 - [Prow github actions available commands](./commands.md)
 - [Labeling issues](./labeling.md)
 - [Automatically Labeling PRs](./examples.md#pr-labeler) (via `actions/labeler` with `pull_request_target`)

--- a/docs/pr-jobs.md
+++ b/docs/pr-jobs.md
@@ -2,11 +2,14 @@
 
 The `jobs` input is space or newline delimited and case-insensitive.
 
-Jobs | Description
---- | ---
-`lgtm` | Removes the `lgtm` label (if present) when the PR is updated, so updated code must be reviewed again before [automatic merging](./automatic-merging.md).
+Jobs | Runs on | Description
+--- | --- | ---
+`lgtm` | `synchronize` only | Removes the `lgtm` label (if present) when new commits are pushed, so updated code must be reviewed again before [automatic merging](./automatic-merging.md).
 
-`lgtm` is the only PR job.
+`lgtm` is the only PR job. Every other activity type (`opened`, `reopened`, `labeled`,
+`unlabeled`, `ready_for_review`, `edited`, `closed`, ...) is logged at debug level and
+skipped, so a workflow may subscribe to `labeled`/`unlabeled` without the job stripping
+the label the moment `/lgtm` adds it.
 
 ```yaml
 name: Run Jobs on PR
@@ -25,4 +28,5 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-The default `pull_request` activity types (`opened`, `synchronize`, `reopened`) are the ones you want; `labeled` is not needed and would not self-trigger removal.
+The default `pull_request` activity types (`opened`, `synchronize`, `reopened`) include
+`synchronize`, so no `types:` filter is needed.

--- a/docs/pr-jobs.md
+++ b/docs/pr-jobs.md
@@ -30,3 +30,31 @@ jobs:
 
 The default `pull_request` activity types (`opened`, `synchronize`, `reopened`) include
 `synchronize`, so no `types:` filter is needed.
+
+## `pull_request_target`
+
+`pull_request_target` carries the same payload as `pull_request` and is routed to the
+same PR jobs. It runs in the context of the base branch with a **write** token, also for
+pull requests from forks, which is what lets the `lgtm` job remove labels on fork PRs
+where `pull_request` only gets a read token.
+
+This is safe only because the action never checks out or executes pull request code.
+Never add `actions/checkout` of the PR head (`ref: ${{ github.event.pull_request.head.sha }}`)
+or run scripts from the PR in a `pull_request_target` job.
+
+```yaml
+name: Run Jobs on PR
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cncf/prow-github-actions@v2
+        with:
+          jobs: lgtm
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+```

--- a/src/issues/handleIssues.ts
+++ b/src/issues/handleIssues.ts
@@ -1,0 +1,17 @@
+import type { Context } from '../utils/context'
+import type { EventHandler } from '../utils/events'
+
+import * as github from '@actions/github'
+import { runEventHandlers } from '../utils/events'
+
+/** handlers that run on every `issues` event; empty until require-matching-label lands */
+export const issueEventHandlers: EventHandler[] = []
+
+/**
+ * Dispatches an `issues` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+export async function handleIssues(context: Context = github.context): Promise<void> {
+  await runEventHandlers('issues', issueEventHandlers, context)
+}

--- a/src/pullReq/handleCheckSuite.ts
+++ b/src/pullReq/handleCheckSuite.ts
@@ -1,0 +1,43 @@
+import type { Octokit } from '@octokit/rest'
+import type { Context } from '../utils/context'
+import type { EventHandler } from '../utils/events'
+
+import * as github from '@actions/github'
+import { runEventHandlers } from '../utils/events'
+
+/** handlers that run on every `check_suite` and `status` event; empty until event-driven merging lands */
+export const checkSuiteHandlers: EventHandler[] = []
+
+/**
+ * Dispatches a `check_suite` or legacy commit `status` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+export async function handleCheckSuite(context: Context = github.context): Promise<void> {
+  await runEventHandlers(context.eventName, checkSuiteHandlers, context)
+}
+
+/**
+ * Lists the numbers of the open pull requests whose head is the given commit,
+ * paging through `pulls.list` until a page comes back empty.
+ *
+ * @param octokit - a hydrated github client
+ * @param context - the github context of the current action event
+ * @param sha - the head commit to look up
+ */
+export async function pullRequestsForSha(octokit: Octokit, context: Context, sha: string): Promise<number[]> {
+  const numbers: number[] = []
+
+  for (let page = 1; ; page++) {
+    const { data } = await octokit.pulls.list({
+      ...context.repo,
+      state: 'open',
+      per_page: 100,
+      page,
+    })
+    if (data.length === 0) {
+      return numbers
+    }
+    numbers.push(...data.filter(pr => pr.head.sha === sha).map(pr => pr.number))
+  }
+}

--- a/src/pullReq/handlePullReq.ts
+++ b/src/pullReq/handlePullReq.ts
@@ -7,11 +7,13 @@ import { onPrLgtm } from './onPrLgtm'
 
 /**
  * This method handles any pull-request configuration for configured workflows.
- * At this time, there are no commands for prow-github-actions
+ * The `lgtm` job only acts on `synchronize` (new commits); every other
+ * activity type is logged and skipped.
  *
  * @param context - the github context of the current action event
  */
 export async function handlePullReq(context: Context = github.context): Promise<void> {
+  const action: string | undefined = context.payload.action
   const runConfig = core
     .getInput('jobs', { required: false })
     .split(/\s+/)
@@ -27,6 +29,10 @@ export async function handlePullReq(context: Context = github.context): Promise<
       core.debug(`${context}`)
       switch (command) {
         case 'lgtm':
+          if (action !== 'synchronize') {
+            core.debug(`skipping pr lgtm job: ${action} pushes no new commits`)
+            return
+          }
           core.debug('running pr lgtm new commit job')
           return await onPrLgtm(context).catch(async (e) => {
             return e

--- a/src/pullReq/handlePullReq.ts
+++ b/src/pullReq/handlePullReq.ts
@@ -1,14 +1,19 @@
 import type { Context } from '../utils/context'
+import type { EventHandler } from '../utils/events'
 
 import * as core from '@actions/core'
 
 import * as github from '@actions/github'
+import { runEventHandlers } from '../utils/events'
 import { onPrLgtm } from './onPrLgtm'
 
+/** handlers that run on every `pull_request` / `pull_request_target` event, next to the `jobs` input; empty for now */
+export const pullRequestHandlers: EventHandler[] = []
+
 /**
- * This method handles any pull-request configuration for configured workflows.
- * The `lgtm` job only acts on `synchronize` (new commits); every other
- * activity type is logged and skipped.
+ * This method handles any pull-request configuration for configured workflows:
+ * the registered handlers and the `jobs` input. The `lgtm` job only acts on
+ * `synchronize` (new commits); every other activity type is logged and skipped.
  *
  * @param context - the github context of the current action event
  */
@@ -23,6 +28,8 @@ export async function handlePullReq(context: Context = github.context): Promise<
   if (runConfig.length === 0) {
     runConfig.push('')
   }
+
+  await runEventHandlers('pull_request', pullRequestHandlers, context)
 
   await Promise.all(
     runConfig.map(async (command) => {

--- a/src/pullReq/handlePullReqReview.ts
+++ b/src/pullReq/handlePullReqReview.ts
@@ -1,0 +1,17 @@
+import type { Context } from '../utils/context'
+import type { EventHandler } from '../utils/events'
+
+import * as github from '@actions/github'
+import { runEventHandlers } from '../utils/events'
+
+/** handlers that run on every `pull_request_review` event; empty for now */
+export const pullRequestReviewHandlers: EventHandler[] = []
+
+/**
+ * Dispatches a `pull_request_review` event to the registered handlers.
+ *
+ * @param context - the github context of the current action event
+ */
+export async function handlePullReqReview(context: Context = github.context): Promise<void> {
+  await runEventHandlers('pull_request_review', pullRequestReviewHandlers, context)
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,31 +1,40 @@
+import type { Context } from './utils/context'
+import type { EventHandler } from './utils/events'
+
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
 import { handleCronJobs } from './cronJobs/handleCronJob'
 import { handleIssueComment } from './issueComment/handleIssueComment'
+import { handleIssues } from './issues/handleIssues'
+import { handleCheckSuite } from './pullReq/handleCheckSuite'
 import { handlePullReq } from './pullReq/handlePullReq'
+import { handlePullReqReview } from './pullReq/handlePullReqReview'
+
+// one row per github event; pull_request_target shares the pull_request payload,
+// status is the legacy commit status that check_suite superseded
+const eventHandlers: Record<string, EventHandler> = {
+  issue_comment: handleIssueComment,
+  issues: handleIssues,
+  pull_request: handlePullReq,
+  pull_request_target: handlePullReq,
+  pull_request_review: handlePullReqReview,
+  check_suite: handleCheckSuite,
+  status: handleCheckSuite,
+  schedule: handleCronJobs,
+  workflow_dispatch: handleCronJobs,
+  push: handleCronJobs,
+}
 
 export async function run(): Promise<void> {
   try {
-    switch (github.context.eventName) {
-      case 'issue_comment':
-        await handleIssueComment()
-        break
-
-      case 'pull_request':
-        await handlePullReq()
-        break
-
-      case 'schedule':
-      case 'workflow_dispatch':
-      case 'push':
-        await handleCronJobs()
-        break
-
-      default:
-        core.error(`${github.context.eventName} not yet supported`)
-        break
+    const context: Context = github.context
+    const handler = Object.hasOwn(eventHandlers, context.eventName) ? eventHandlers[context.eventName] : undefined
+    if (!handler) {
+      core.error(`${context.eventName} not yet supported`)
+      return
     }
+    await handler(context)
   }
   catch (error) {
     core.setFailed(error instanceof Error ? error.message : String(error))

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,31 @@
+import type { Context } from './context'
+
+import * as core from '@actions/core'
+
+export type EventHandler = (context: Context) => Promise<void>
+
+/**
+ * Runs every registered handler for an event and fails the run once with the
+ * collected rejections. An empty registry is a debug-logged no-op.
+ *
+ * @param event - the github event name
+ * @param handlers - the registry to run
+ * @param context - the github context of the current action event
+ */
+export async function runEventHandlers(event: string, handlers: EventHandler[], context: Context): Promise<void> {
+  const action: string | undefined = context.payload.action
+
+  if (handlers.length === 0) {
+    core.debug(`${event} event ${action} received; no handlers registered yet`)
+    return
+  }
+
+  const results = await Promise.all(
+    handlers.map(handler => handler(context).catch((e: unknown) => (e instanceof Error ? e : new Error(String(e))))),
+  )
+
+  const errors = results.filter((result): result is Error => result instanceof Error)
+  if (errors.length > 0) {
+    core.setFailed(`error handling ${event} event: ${errors.map(e => e.message).join('; ')}`)
+  }
+}


### PR DESCRIPTION
# Description

PR 3 of the org-wide install sequence: **event routing plumbing** so the next PRs (`require-matching-label`, `owners-label`, `blunderbuss`, event-driven merge) have events to hook. No new user-facing features; one behaviour fix.

## `fix(pr-jobs): only remove lgtm when new commits are pushed`
`onPrLgtm` (the `jobs: lgtm` PR job) removed `lgtm` on **every** `pull_request` activity — it never looked at `payload.action`. It only appeared correct because `on: pull_request`'s default types happen to exclude `labeled`. Once a repo subscribes to label events (which `require-matching-label` needs), `/lgtm` would be undone the instant it lands. It now runs only on `synchronize`, which is what the docs always said. Failing-test-first: 11 red on `main` (opened/reopened/labeled/unlabeled/… all DELETEd).

## `feat: route issues, pull_request_review, check_suite and pull_request_target events`
`run.ts`'s switch becomes a dispatch table (with an `Object.hasOwn` guard so an event named `toString` can't dispatch). New rows: `issues`, `pull_request_review`, `check_suite`, `status`, `pull_request_target` (→ same handler as `pull_request`). Each new event has a dispatcher with an **empty handler registry** and shared error aggregation (`runEventHandlers`) — later PRs push a function in. `pullRequestsForSha` (for `check_suite`/`status`, which carry a SHA not a PR) lands now, tested. Unknown events keep the exact `<event> not yet supported` error.

`pull_request_target` runs with a write token on fork PRs. Docs state the safety rule plainly: it is safe **only** because the action never checks out or executes PR code — never add a PR-head checkout to a `pull_request_target` job. New `docs/events.md` tables what's handled vs routed-only.

## Testing
- **584 → 623 tests**; coverage 94.8 / 95.3 br / 99.6 fn
- Assertions changed (all from the fix): six `handlePullReq`/`onPrLgtm` tests and one bundle scenario now build the context with `action: synchronize` (previously relied on `opened` — the bug); the "unsupported event" example moves from `issues` to `release`; `run.test.ts` is table-driven across all 10 rows and asserts no *other* handler ran.
- Five new bundle-harness scenarios: `issues`/`pull_request_review`/`check_suite` events → exit 0 with **zero** API calls; `pull_request labeled` → no DELETE.
- Hermetic under a simulated Actions env; `dist/` byte-identical across repeated packs.

Next: PR 4 — `require-matching-label` (the `needs-*` mechanism).
